### PR TITLE
Implements Authentication using Firebase during SSR

### DIFF
--- a/client/.gitignore
+++ b/client/.gitignore
@@ -8,3 +8,6 @@ node_modules
 !.env.example
 .vercel
 .output
+
+// Credentials
+*-firebase-adminsdk-*.json

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -10,7 +10,8 @@
 			"dependencies": {
 				"@fontsource/fira-mono": "^4.5.0",
 				"cookie": "^0.4.1",
-				"firebase": "^9.9.0"
+				"firebase": "^9.9.0",
+				"firebase-admin": "^11.0.0"
 			},
 			"devDependencies": {
 				"@playwright/test": "^1.22.2",
@@ -50,6 +51,17 @@
 			},
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			}
+		},
+		"node_modules/@fastify/busboy": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-1.1.0.tgz",
+			"integrity": "sha512-Fv854f94v0CzIDllbY3i/0NJPNBRNLDawf3BTYVGCe9VrIIs3Wi7AFx24F9NzCxdf0wyx/x0Q9kEVnvDOPnlxA==",
+			"dependencies": {
+				"text-decoding": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=10.17.0"
 			}
 		},
 		"node_modules/@firebase/analytics": {
@@ -551,6 +563,83 @@
 			"resolved": "https://registry.npmjs.org/@fontsource/fira-mono/-/fira-mono-4.5.8.tgz",
 			"integrity": "sha512-sFuSPB/Km8B1fy3CH0NqO5Nb4GmVMzp3XFaw6MwK293xhm3OnB68QJawwTTjLewcrS78wOTAhTUB058qxurJoQ=="
 		},
+		"node_modules/@google-cloud/firestore": {
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/@google-cloud/firestore/-/firestore-5.0.2.tgz",
+			"integrity": "sha512-xlGcNYaW0nvUMzNn2+pLfbEBVt6oysVqtM89faMgZWkWfEtvIQGS0h5PRdLlcqufNzRCX3yIGv29Pb+03ys+VA==",
+			"optional": true,
+			"dependencies": {
+				"fast-deep-equal": "^3.1.1",
+				"functional-red-black-tree": "^1.0.1",
+				"google-gax": "^2.24.1",
+				"protobufjs": "^6.8.6"
+			},
+			"engines": {
+				"node": ">=10.10.0"
+			}
+		},
+		"node_modules/@google-cloud/paginator": {
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/@google-cloud/paginator/-/paginator-3.0.7.tgz",
+			"integrity": "sha512-jJNutk0arIQhmpUUQJPJErsojqo834KcyB6X7a1mxuic8i1tKXxde8E69IZxNZawRIlZdIK2QY4WALvlK5MzYQ==",
+			"optional": true,
+			"dependencies": {
+				"arrify": "^2.0.0",
+				"extend": "^3.0.2"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@google-cloud/projectify": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@google-cloud/projectify/-/projectify-3.0.0.tgz",
+			"integrity": "sha512-HRkZsNmjScY6Li8/kb70wjGlDDyLkVk3KvoEo9uIoxSjYLJasGiCch9+PqRVDOCGUFvEIqyogl+BeqILL4OJHA==",
+			"optional": true,
+			"engines": {
+				"node": ">=12.0.0"
+			}
+		},
+		"node_modules/@google-cloud/promisify": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@google-cloud/promisify/-/promisify-3.0.0.tgz",
+			"integrity": "sha512-91ArYvRgXWb73YvEOBMmOcJc0bDRs5yiVHnqkwoG0f3nm7nZuipllz6e7BvFESBvjkDTBC0zMD8QxedUwNLc1A==",
+			"optional": true,
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@google-cloud/storage": {
+			"version": "6.2.3",
+			"resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-6.2.3.tgz",
+			"integrity": "sha512-UJqn3Ln8wFBPLuwBaNu3PlhzQDL3EKKfP1+3mzLRQhcFqgpBSMPLDgAXxc6e9S0l0kqsi4GOuAA7fA+l/VAMjQ==",
+			"optional": true,
+			"dependencies": {
+				"@google-cloud/paginator": "^3.0.7",
+				"@google-cloud/projectify": "^3.0.0",
+				"@google-cloud/promisify": "^3.0.0",
+				"abort-controller": "^3.0.0",
+				"arrify": "^2.0.0",
+				"async-retry": "^1.3.3",
+				"compressible": "^2.0.12",
+				"duplexify": "^4.0.0",
+				"ent": "^2.2.0",
+				"extend": "^3.0.2",
+				"gaxios": "^5.0.0",
+				"google-auth-library": "^8.0.1",
+				"mime": "^3.0.0",
+				"mime-types": "^2.0.8",
+				"p-limit": "^3.0.1",
+				"pumpify": "^2.0.0",
+				"retry-request": "^5.0.0",
+				"stream-events": "^1.0.4",
+				"teeny-request": "^8.0.0",
+				"uuid": "^8.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
 		"node_modules/@grpc/grpc-js": {
 			"version": "1.6.7",
 			"resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.6.7.tgz",
@@ -685,6 +774,14 @@
 			},
 			"engines": {
 				"node": ">= 8"
+			}
+		},
+		"node_modules/@panva/asn1.js": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@panva/asn1.js/-/asn1.js-1.0.0.tgz",
+			"integrity": "sha512-UdkG3mLEqXgnlKsWanWcgb6dOjUzJ+XC5f+aWw30qrtjxeNUSfKX1cd5FBzOaXQumoe9nIqeZUvrRJS03HCCtw==",
+			"engines": {
+				"node": ">=10.13.0"
 			}
 		},
 		"node_modules/@playwright/test": {
@@ -861,11 +958,58 @@
 				}
 			}
 		},
+		"node_modules/@tootallnate/once": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
+			"integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+			"optional": true,
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@types/body-parser": {
+			"version": "1.19.2",
+			"resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz",
+			"integrity": "sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==",
+			"dependencies": {
+				"@types/connect": "*",
+				"@types/node": "*"
+			}
+		},
+		"node_modules/@types/connect": {
+			"version": "3.4.35",
+			"resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
+			"integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
+			"dependencies": {
+				"@types/node": "*"
+			}
+		},
 		"node_modules/@types/cookie": {
 			"version": "0.5.1",
 			"resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.5.1.tgz",
 			"integrity": "sha512-COUnqfB2+ckwXXSFInsFdOAWQzCCx+a5hq2ruyj+Vjund94RJQd4LG2u9hnvJrTgunKAaax7ancBYlDrNYxA0g==",
 			"dev": true
+		},
+		"node_modules/@types/express": {
+			"version": "4.17.13",
+			"resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz",
+			"integrity": "sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==",
+			"dependencies": {
+				"@types/body-parser": "*",
+				"@types/express-serve-static-core": "^4.17.18",
+				"@types/qs": "*",
+				"@types/serve-static": "*"
+			}
+		},
+		"node_modules/@types/express-serve-static-core": {
+			"version": "4.17.29",
+			"resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.29.tgz",
+			"integrity": "sha512-uMd++6dMKS32EOuw1Uli3e3BPgdLIXmezcfHv7N4c1s3gkhikBplORPpMq3fuWkxncZN1reb16d5n8yhQ80x7Q==",
+			"dependencies": {
+				"@types/node": "*",
+				"@types/qs": "*",
+				"@types/range-parser": "*"
+			}
 		},
 		"node_modules/@types/json-schema": {
 			"version": "7.0.11",
@@ -873,10 +1017,23 @@
 			"integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
 			"dev": true
 		},
+		"node_modules/@types/jsonwebtoken": {
+			"version": "8.5.8",
+			"resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-8.5.8.tgz",
+			"integrity": "sha512-zm6xBQpFDIDM6o9r6HSgDeIcLy82TKWctCXEPbJJcXb5AKmi5BNNdLXneixK4lplX3PqIVcwLBCGE/kAGnlD4A==",
+			"dependencies": {
+				"@types/node": "*"
+			}
+		},
 		"node_modules/@types/long": {
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
 			"integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA=="
+		},
+		"node_modules/@types/mime": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
+			"integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw=="
 		},
 		"node_modules/@types/node": {
 			"version": "18.0.3",
@@ -889,12 +1046,31 @@
 			"integrity": "sha512-SnHmG9wN1UVmagJOnyo/qkk0Z7gejYxOYYmaAwr5u2yFYfsupN3sg10kyzN8Hep/2zbHxCnsumxOoRIRMBwKCg==",
 			"dev": true
 		},
+		"node_modules/@types/qs": {
+			"version": "6.9.7",
+			"resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
+			"integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw=="
+		},
+		"node_modules/@types/range-parser": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
+			"integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw=="
+		},
 		"node_modules/@types/sass": {
 			"version": "1.43.1",
 			"resolved": "https://registry.npmjs.org/@types/sass/-/sass-1.43.1.tgz",
 			"integrity": "sha512-BPdoIt1lfJ6B7rw35ncdwBZrAssjcwzI5LByIrYs+tpXlj/CAkuVdRsgZDdP4lq5EjyWzwxZCqAoFyHKFwp32g==",
 			"dev": true,
 			"dependencies": {
+				"@types/node": "*"
+			}
+		},
+		"node_modules/@types/serve-static": {
+			"version": "1.13.10",
+			"resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.10.tgz",
+			"integrity": "sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==",
+			"dependencies": {
+				"@types/mime": "^1",
 				"@types/node": "*"
 			}
 		},
@@ -1109,6 +1285,18 @@
 			"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
 			"dev": true
 		},
+		"node_modules/abort-controller": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+			"integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+			"optional": true,
+			"dependencies": {
+				"event-target-shim": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=6.5"
+			}
+		},
 		"node_modules/acorn": {
 			"version": "8.7.1",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
@@ -1134,7 +1322,7 @@
 			"version": "6.0.2",
 			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
 			"integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-			"dev": true,
+			"devOptional": true,
 			"dependencies": {
 				"debug": "4"
 			},
@@ -1227,10 +1415,57 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/arrify": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
+			"integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
+			"optional": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/async-retry": {
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
+			"integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
+			"optional": true,
+			"dependencies": {
+				"retry": "0.13.1"
+			}
+		},
 		"node_modules/balanced-match": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
 			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+		},
+		"node_modules/base64-js": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"optional": true
+		},
+		"node_modules/bignumber.js": {
+			"version": "9.0.2",
+			"resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.2.tgz",
+			"integrity": "sha512-GAcQvbpsM0pUb0zw1EI0KhQEZ+lRwR5fYaAp3vPOYuP7aDvGy6cVN6XHLauvF8SOga2y0dcLcjt3iQDTSEliyw==",
+			"optional": true,
+			"engines": {
+				"node": "*"
+			}
 		},
 		"node_modules/binary-extensions": {
 			"version": "2.2.0",
@@ -1279,6 +1514,11 @@
 			"engines": {
 				"node": "*"
 			}
+		},
+		"node_modules/buffer-equal-constant-time": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+			"integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
 		},
 		"node_modules/callsites": {
 			"version": "3.1.0",
@@ -1376,6 +1616,18 @@
 				"color-support": "bin.js"
 			}
 		},
+		"node_modules/compressible": {
+			"version": "2.0.18",
+			"resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
+			"integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
+			"optional": true,
+			"dependencies": {
+				"mime-db": ">= 1.43.0 < 2"
+			},
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
 		"node_modules/concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -1429,7 +1681,6 @@
 			"version": "4.3.4",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
 			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-			"dev": true,
 			"dependencies": {
 				"ms": "2.1.2"
 			},
@@ -1505,10 +1756,45 @@
 				"node": ">=6.0.0"
 			}
 		},
+		"node_modules/duplexify": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.2.tgz",
+			"integrity": "sha512-fz3OjcNCHmRP12MJoZMPglx8m4rrFP8rovnk4vT8Fs+aonZoCwGg10dSsQsfP/E62eZcPTMSMP6686fu9Qlqtw==",
+			"optional": true,
+			"dependencies": {
+				"end-of-stream": "^1.4.1",
+				"inherits": "^2.0.3",
+				"readable-stream": "^3.1.1",
+				"stream-shift": "^1.0.0"
+			}
+		},
+		"node_modules/ecdsa-sig-formatter": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+			"integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+			"dependencies": {
+				"safe-buffer": "^5.0.1"
+			}
+		},
 		"node_modules/emoji-regex": {
 			"version": "8.0.0",
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
 			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+		},
+		"node_modules/end-of-stream": {
+			"version": "1.4.4",
+			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+			"integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+			"optional": true,
+			"dependencies": {
+				"once": "^1.4.0"
+			}
+		},
+		"node_modules/ent": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/ent/-/ent-2.2.0.tgz",
+			"integrity": "sha512-GHrMyVZQWvTIdDtpiEXdHZnFQKzeO09apj8Cbl4pKWy4i0Oprcq17usfDt5aO63swf0JOeMWjWQE/LzgSRuWpA==",
+			"optional": true
 		},
 		"node_modules/es6-promise": {
 			"version": "3.3.1",
@@ -2128,11 +2414,26 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/event-target-shim": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+			"integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+			"optional": true,
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/extend": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+			"optional": true
+		},
 		"node_modules/fast-deep-equal": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
 			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-			"dev": true
+			"devOptional": true
 		},
 		"node_modules/fast-glob": {
 			"version": "3.2.11",
@@ -2161,6 +2462,12 @@
 			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
 			"integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
 			"dev": true
+		},
+		"node_modules/fast-text-encoding": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/fast-text-encoding/-/fast-text-encoding-1.0.4.tgz",
+			"integrity": "sha512-x6lDDm/tBAzX9kmsPcZsNbvDs3Zey3+scsxaZElS8xWLgUMAg/oFLeewfUz0mu1CblHhhsu15jGkraldkFh8KQ==",
+			"optional": true
 		},
 		"node_modules/fastq": {
 			"version": "1.13.0",
@@ -2246,6 +2553,28 @@
 				"@firebase/util": "1.6.3"
 			}
 		},
+		"node_modules/firebase-admin": {
+			"version": "11.0.0",
+			"resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-11.0.0.tgz",
+			"integrity": "sha512-x56u+Q1P8QDvQKaYRe29ZUM/3f829cP8tsKCDXOhaIX/GbGfgcdjRhPmCafzlwgCWP5wW9NkOgIhnrw94zucvw==",
+			"dependencies": {
+				"@fastify/busboy": "^1.1.0",
+				"@firebase/database-compat": "^0.2.0",
+				"@firebase/database-types": "^0.9.7",
+				"@types/node": ">=12.12.47",
+				"jsonwebtoken": "^8.5.1",
+				"jwks-rsa": "^2.0.2",
+				"node-forge": "^1.3.1",
+				"uuid": "^8.3.2"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"optionalDependencies": {
+				"@google-cloud/firestore": "^5.0.2",
+				"@google-cloud/storage": "^6.1.0"
+			}
+		},
 		"node_modules/flat-cache": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
@@ -2306,7 +2635,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
 			"integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
-			"dev": true
+			"devOptional": true
 		},
 		"node_modules/gauge": {
 			"version": "3.0.2",
@@ -2326,6 +2655,34 @@
 			},
 			"engines": {
 				"node": ">=10"
+			}
+		},
+		"node_modules/gaxios": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/gaxios/-/gaxios-5.0.1.tgz",
+			"integrity": "sha512-keK47BGKHyyOVQxgcUaSaFvr3ehZYAlvhvpHXy0YB2itzZef+GqZR8TBsfVRWghdwlKrYsn+8L8i3eblF7Oviw==",
+			"optional": true,
+			"dependencies": {
+				"extend": "^3.0.2",
+				"https-proxy-agent": "^5.0.0",
+				"is-stream": "^2.0.0",
+				"node-fetch": "^2.6.7"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/gcp-metadata": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-5.0.0.tgz",
+			"integrity": "sha512-gfwuX3yA3nNsHSWUL4KG90UulNiq922Ukj3wLTrcnX33BB7PwB1o0ubR8KVvXu9nJH+P5w1j2SQSNNqto+H0DA==",
+			"optional": true,
+			"dependencies": {
+				"gaxios": "^5.0.0",
+				"json-bigint": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=12"
 			}
 		},
 		"node_modules/get-caller-file": {
@@ -2414,11 +2771,194 @@
 			"integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
 			"dev": true
 		},
+		"node_modules/google-auth-library": {
+			"version": "8.1.1",
+			"resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-8.1.1.tgz",
+			"integrity": "sha512-eG3pCfrLgVJe19KhAeZwW0m1LplNEo0FX1GboWf3hu18zD2jq8TUH2K8900AB2YRAuJ7A+1aSXDp1BODjwwRzg==",
+			"optional": true,
+			"dependencies": {
+				"arrify": "^2.0.0",
+				"base64-js": "^1.3.0",
+				"ecdsa-sig-formatter": "^1.0.11",
+				"fast-text-encoding": "^1.0.0",
+				"gaxios": "^5.0.0",
+				"gcp-metadata": "^5.0.0",
+				"gtoken": "^6.0.0",
+				"jws": "^4.0.0",
+				"lru-cache": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/google-gax": {
+			"version": "2.30.5",
+			"resolved": "https://registry.npmjs.org/google-gax/-/google-gax-2.30.5.tgz",
+			"integrity": "sha512-Jey13YrAN2hfpozHzbtrwEfEHdStJh1GwaQ2+Akh1k0Tv/EuNVSuBtHZoKSBm5wBMvNsxTsEIZ/152NrYyZgxQ==",
+			"optional": true,
+			"dependencies": {
+				"@grpc/grpc-js": "~1.6.0",
+				"@grpc/proto-loader": "^0.6.12",
+				"@types/long": "^4.0.0",
+				"abort-controller": "^3.0.0",
+				"duplexify": "^4.0.0",
+				"fast-text-encoding": "^1.0.3",
+				"google-auth-library": "^7.14.0",
+				"is-stream-ended": "^0.1.4",
+				"node-fetch": "^2.6.1",
+				"object-hash": "^3.0.0",
+				"proto3-json-serializer": "^0.1.8",
+				"protobufjs": "6.11.3",
+				"retry-request": "^4.0.0"
+			},
+			"bin": {
+				"compileProtos": "build/tools/compileProtos.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/google-gax/node_modules/gaxios": {
+			"version": "4.3.3",
+			"resolved": "https://registry.npmjs.org/gaxios/-/gaxios-4.3.3.tgz",
+			"integrity": "sha512-gSaYYIO1Y3wUtdfHmjDUZ8LWaxJQpiavzbF5Kq53akSzvmVg0RfyOcFDbO1KJ/KCGRFz2qG+lS81F0nkr7cRJA==",
+			"optional": true,
+			"dependencies": {
+				"abort-controller": "^3.0.0",
+				"extend": "^3.0.2",
+				"https-proxy-agent": "^5.0.0",
+				"is-stream": "^2.0.0",
+				"node-fetch": "^2.6.7"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/google-gax/node_modules/gcp-metadata": {
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-4.3.1.tgz",
+			"integrity": "sha512-x850LS5N7V1F3UcV7PoupzGsyD6iVwTVvsh3tbXfkctZnBnjW5yu5z1/3k3SehF7TyoTIe78rJs02GMMy+LF+A==",
+			"optional": true,
+			"dependencies": {
+				"gaxios": "^4.0.0",
+				"json-bigint": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/google-gax/node_modules/google-auth-library": {
+			"version": "7.14.1",
+			"resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-7.14.1.tgz",
+			"integrity": "sha512-5Rk7iLNDFhFeBYc3s8l1CqzbEBcdhwR193RlD4vSNFajIcINKI8W8P0JLmBpwymHqqWbX34pJDQu39cSy/6RsA==",
+			"optional": true,
+			"dependencies": {
+				"arrify": "^2.0.0",
+				"base64-js": "^1.3.0",
+				"ecdsa-sig-formatter": "^1.0.11",
+				"fast-text-encoding": "^1.0.0",
+				"gaxios": "^4.0.0",
+				"gcp-metadata": "^4.2.0",
+				"gtoken": "^5.0.4",
+				"jws": "^4.0.0",
+				"lru-cache": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/google-gax/node_modules/google-p12-pem": {
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-3.1.4.tgz",
+			"integrity": "sha512-HHuHmkLgwjdmVRngf5+gSmpkyaRI6QmOg77J8tkNBHhNEI62sGHyw4/+UkgyZEI7h84NbWprXDJ+sa3xOYFvTg==",
+			"optional": true,
+			"dependencies": {
+				"node-forge": "^1.3.1"
+			},
+			"bin": {
+				"gp12-pem": "build/src/bin/gp12-pem.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/google-gax/node_modules/gtoken": {
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/gtoken/-/gtoken-5.3.2.tgz",
+			"integrity": "sha512-gkvEKREW7dXWF8NV8pVrKfW7WqReAmjjkMBh6lNCCGOM4ucS0r0YyXXl0r/9Yj8wcW/32ISkfc8h5mPTDbtifQ==",
+			"optional": true,
+			"dependencies": {
+				"gaxios": "^4.0.0",
+				"google-p12-pem": "^3.1.3",
+				"jws": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/google-gax/node_modules/retry-request": {
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/retry-request/-/retry-request-4.2.2.tgz",
+			"integrity": "sha512-xA93uxUD/rogV7BV59agW/JHPGXeREMWiZc9jhcwY4YdZ7QOtC7qbomYg0n4wyk2lJhggjvKvhNX8wln/Aldhg==",
+			"optional": true,
+			"dependencies": {
+				"debug": "^4.1.1",
+				"extend": "^3.0.2"
+			},
+			"engines": {
+				"node": ">=8.10.0"
+			}
+		},
+		"node_modules/google-p12-pem": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-4.0.0.tgz",
+			"integrity": "sha512-lRTMn5ElBdDixv4a86bixejPSRk1boRtUowNepeKEVvYiFlkLuAJUVpEz6PfObDHYEKnZWq/9a2zC98xu62A9w==",
+			"optional": true,
+			"dependencies": {
+				"node-forge": "^1.3.1"
+			},
+			"bin": {
+				"gp12-pem": "build/src/bin/gp12-pem.js"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			}
+		},
 		"node_modules/graceful-fs": {
 			"version": "4.2.10",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
 			"integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
 			"dev": true
+		},
+		"node_modules/gtoken": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/gtoken/-/gtoken-6.1.0.tgz",
+			"integrity": "sha512-WPZcFw34wh2LUvbCUWI70GDhOlO7qHpSvFHFqq7d3Wvsf8dIJedE0lnUdOmsKuC0NgflKmF0LxIF38vsGeHHiQ==",
+			"optional": true,
+			"dependencies": {
+				"gaxios": "^4.0.0",
+				"google-p12-pem": "^4.0.0",
+				"jws": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			}
+		},
+		"node_modules/gtoken/node_modules/gaxios": {
+			"version": "4.3.3",
+			"resolved": "https://registry.npmjs.org/gaxios/-/gaxios-4.3.3.tgz",
+			"integrity": "sha512-gSaYYIO1Y3wUtdfHmjDUZ8LWaxJQpiavzbF5Kq53akSzvmVg0RfyOcFDbO1KJ/KCGRFz2qG+lS81F0nkr7cRJA==",
+			"optional": true,
+			"dependencies": {
+				"abort-controller": "^3.0.0",
+				"extend": "^3.0.2",
+				"https-proxy-agent": "^5.0.0",
+				"is-stream": "^2.0.0",
+				"node-fetch": "^2.6.7"
+			},
+			"engines": {
+				"node": ">=10"
+			}
 		},
 		"node_modules/has": {
 			"version": "1.0.3",
@@ -2452,11 +2992,25 @@
 			"resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.8.tgz",
 			"integrity": "sha512-SGeBX54F94Wgu5RH3X5jsDtf4eHyRogWX1XGT3b4HuW3tQPM4AaBzoUji/4AAJNXCEOWZ5O0DgZmJw1947gD5Q=="
 		},
+		"node_modules/http-proxy-agent": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+			"integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+			"optional": true,
+			"dependencies": {
+				"@tootallnate/once": "2",
+				"agent-base": "6",
+				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
 		"node_modules/https-proxy-agent": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
 			"integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-			"dev": true,
+			"devOptional": true,
 			"dependencies": {
 				"agent-base": "6",
 				"debug": "4"
@@ -2594,6 +3148,24 @@
 				"node": ">=0.12.0"
 			}
 		},
+		"node_modules/is-stream": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+			"integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+			"optional": true,
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/is-stream-ended": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/is-stream-ended/-/is-stream-ended-0.1.4.tgz",
+			"integrity": "sha512-xj0XPvmr7bQFTvirqnFr50o0hQIh6ZItDqloxt5aJrR4NQsYeSsyFQERYGCAzfindAcnKjINnwEEgLx4IqVzQw==",
+			"optional": true
+		},
 		"node_modules/isarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -2604,6 +3176,20 @@
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
 			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
 			"dev": true
+		},
+		"node_modules/jose": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/jose/-/jose-2.0.5.tgz",
+			"integrity": "sha512-BAiDNeDKTMgk4tvD0BbxJ8xHEHBZgpeRZ1zGPPsitSyMgjoMWiLGYAE7H7NpP5h0lPppQajQs871E8NHUrzVPA==",
+			"dependencies": {
+				"@panva/asn1.js": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=10.13.0 < 13 || >=13.7.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/panva"
+			}
 		},
 		"node_modules/js-yaml": {
 			"version": "4.1.0",
@@ -2617,6 +3203,15 @@
 				"js-yaml": "bin/js-yaml.js"
 			}
 		},
+		"node_modules/json-bigint": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+			"integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+			"optional": true,
+			"dependencies": {
+				"bignumber.js": "^9.0.0"
+			}
+		},
 		"node_modules/json-schema-traverse": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -2628,6 +3223,54 @@
 			"resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
 			"integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
 			"dev": true
+		},
+		"node_modules/jsonwebtoken": {
+			"version": "8.5.1",
+			"resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
+			"integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
+			"dependencies": {
+				"jws": "^3.2.2",
+				"lodash.includes": "^4.3.0",
+				"lodash.isboolean": "^3.0.3",
+				"lodash.isinteger": "^4.0.4",
+				"lodash.isnumber": "^3.0.3",
+				"lodash.isplainobject": "^4.0.6",
+				"lodash.isstring": "^4.0.1",
+				"lodash.once": "^4.0.0",
+				"ms": "^2.1.1",
+				"semver": "^5.6.0"
+			},
+			"engines": {
+				"node": ">=4",
+				"npm": ">=1.4.28"
+			}
+		},
+		"node_modules/jsonwebtoken/node_modules/jwa": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+			"integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+			"dependencies": {
+				"buffer-equal-constant-time": "1.0.1",
+				"ecdsa-sig-formatter": "1.0.11",
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"node_modules/jsonwebtoken/node_modules/jws": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+			"integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+			"dependencies": {
+				"jwa": "^1.4.1",
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"node_modules/jsonwebtoken/node_modules/semver": {
+			"version": "5.7.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+			"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+			"bin": {
+				"semver": "bin/semver"
+			}
 		},
 		"node_modules/jszip": {
 			"version": "3.10.0",
@@ -2667,6 +3310,43 @@
 				"safe-buffer": "~5.1.0"
 			}
 		},
+		"node_modules/jwa": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.0.tgz",
+			"integrity": "sha512-jrZ2Qx916EA+fq9cEAeCROWPTfCwi1IVHqT2tapuqLEVVDKFDENFw1oL+MwrTvH6msKxsd1YTDVw6uKEcsrLEA==",
+			"optional": true,
+			"dependencies": {
+				"buffer-equal-constant-time": "1.0.1",
+				"ecdsa-sig-formatter": "1.0.11",
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"node_modules/jwks-rsa": {
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/jwks-rsa/-/jwks-rsa-2.1.4.tgz",
+			"integrity": "sha512-mpArfgPkUpX11lNtGxsF/szkasUcbWHGplZl/uFvFO2NuMHmt0dQXIihh0rkPU2yQd5niQtuUHbXnG/WKiXF6Q==",
+			"dependencies": {
+				"@types/express": "^4.17.13",
+				"@types/jsonwebtoken": "^8.5.8",
+				"debug": "^4.3.4",
+				"jose": "^2.0.5",
+				"limiter": "^1.1.5",
+				"lru-memoizer": "^2.1.4"
+			},
+			"engines": {
+				"node": ">=10 < 13 || >=14"
+			}
+		},
+		"node_modules/jws": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
+			"integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
+			"optional": true,
+			"dependencies": {
+				"jwa": "^2.0.0",
+				"safe-buffer": "^5.0.1"
+			}
+		},
 		"node_modules/kleur": {
 			"version": "4.1.5",
 			"resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
@@ -2697,16 +3377,61 @@
 				"immediate": "~3.0.5"
 			}
 		},
+		"node_modules/limiter": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/limiter/-/limiter-1.1.5.tgz",
+			"integrity": "sha512-FWWMIEOxz3GwUI4Ts/IvgVy6LPvoMPgjMdQ185nN6psJyBJ4yOpzqm695/h5umdLJg2vW3GR5iG11MAkR2AzJA=="
+		},
 		"node_modules/lodash.camelcase": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
 			"integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA=="
+		},
+		"node_modules/lodash.clonedeep": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+			"integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ=="
+		},
+		"node_modules/lodash.includes": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+			"integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w=="
+		},
+		"node_modules/lodash.isboolean": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+			"integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg=="
+		},
+		"node_modules/lodash.isinteger": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+			"integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA=="
+		},
+		"node_modules/lodash.isnumber": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+			"integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw=="
+		},
+		"node_modules/lodash.isplainobject": {
+			"version": "4.0.6",
+			"resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+			"integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA=="
+		},
+		"node_modules/lodash.isstring": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+			"integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw=="
 		},
 		"node_modules/lodash.merge": {
 			"version": "4.6.2",
 			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
 			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
 			"dev": true
+		},
+		"node_modules/lodash.once": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+			"integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="
 		},
 		"node_modules/long": {
 			"version": "4.0.0",
@@ -2717,13 +3442,36 @@
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
 			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-			"dev": true,
+			"devOptional": true,
 			"dependencies": {
 				"yallist": "^4.0.0"
 			},
 			"engines": {
 				"node": ">=10"
 			}
+		},
+		"node_modules/lru-memoizer": {
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/lru-memoizer/-/lru-memoizer-2.1.4.tgz",
+			"integrity": "sha512-IXAq50s4qwrOBrXJklY+KhgZF+5y98PDaNo0gi/v2KQBFLyWr+JyFvijZXkGKjQj/h9c0OwoE+JZbwUXce76hQ==",
+			"dependencies": {
+				"lodash.clonedeep": "^4.5.0",
+				"lru-cache": "~4.0.0"
+			}
+		},
+		"node_modules/lru-memoizer/node_modules/lru-cache": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.2.tgz",
+			"integrity": "sha512-uQw9OqphAGiZhkuPlpFGmdTU2tEuhxTourM/19qGJrxBPHAr/f8BT1a0i/lOclESnGatdJG/UCkP9kZB/Lh1iw==",
+			"dependencies": {
+				"pseudomap": "^1.0.1",
+				"yallist": "^2.0.0"
+			}
+		},
+		"node_modules/lru-memoizer/node_modules/yallist": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+			"integrity": "sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A=="
 		},
 		"node_modules/magic-string": {
 			"version": "0.26.2",
@@ -2781,6 +3529,39 @@
 			},
 			"engines": {
 				"node": ">=8.6"
+			}
+		},
+		"node_modules/mime": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+			"integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
+			"optional": true,
+			"bin": {
+				"mime": "cli.js"
+			},
+			"engines": {
+				"node": ">=10.0.0"
+			}
+		},
+		"node_modules/mime-db": {
+			"version": "1.52.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+			"integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+			"optional": true,
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/mime-types": {
+			"version": "2.1.35",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+			"integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+			"optional": true,
+			"dependencies": {
+				"mime-db": "1.52.0"
+			},
+			"engines": {
+				"node": ">= 0.6"
 			}
 		},
 		"node_modules/min-indent": {
@@ -2867,8 +3648,7 @@
 		"node_modules/ms": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-			"dev": true
+			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
 		},
 		"node_modules/nanoid": {
 			"version": "3.3.4",
@@ -2905,6 +3685,14 @@
 				"encoding": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/node-forge": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
+			"integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
+			"engines": {
+				"node": ">= 6.13.0"
 			}
 		},
 		"node_modules/node-gyp-build": {
@@ -2963,6 +3751,15 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/object-hash": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+			"integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+			"optional": true,
+			"engines": {
+				"node": ">= 6"
+			}
+		},
 		"node_modules/once": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -2986,6 +3783,21 @@
 			},
 			"engines": {
 				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/p-limit": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+			"integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+			"optional": true,
+			"dependencies": {
+				"yocto-queue": "^0.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/pako": {
@@ -3135,6 +3947,15 @@
 			"resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.1.3.tgz",
 			"integrity": "sha512-MG5r82wBzh7pSKDRa9y+vllNHz3e3d4CNj1PQE4BQYxLme0gKYYBm9YENq+UkEikyZ0XbiGWxYlVw3Rl9O/U8g=="
 		},
+		"node_modules/proto3-json-serializer": {
+			"version": "0.1.9",
+			"resolved": "https://registry.npmjs.org/proto3-json-serializer/-/proto3-json-serializer-0.1.9.tgz",
+			"integrity": "sha512-A60IisqvnuI45qNRygJjrnNjX2TMdQGMY+57tR3nul3ZgO2zXkR9OGR8AXxJhkqx84g0FTnrfi3D5fWMSdANdQ==",
+			"optional": true,
+			"dependencies": {
+				"protobufjs": "^6.11.2"
+			}
+		},
 		"node_modules/protobufjs": {
 			"version": "6.11.3",
 			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.3.tgz",
@@ -3158,6 +3979,32 @@
 			"bin": {
 				"pbjs": "bin/pbjs",
 				"pbts": "bin/pbts"
+			}
+		},
+		"node_modules/pseudomap": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+			"integrity": "sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ=="
+		},
+		"node_modules/pump": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+			"integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+			"optional": true,
+			"dependencies": {
+				"end-of-stream": "^1.1.0",
+				"once": "^1.3.1"
+			}
+		},
+		"node_modules/pumpify": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/pumpify/-/pumpify-2.0.1.tgz",
+			"integrity": "sha512-m7KOje7jZxrmutanlkS1daj1dS6z6BgslzOXmcSEpIlCxM3VJH7lG5QLeck/6hgF6F4crFf01UtQmNsJfweTAw==",
+			"optional": true,
+			"dependencies": {
+				"duplexify": "^4.1.1",
+				"inherits": "^2.0.3",
+				"pump": "^3.0.0"
 			}
 		},
 		"node_modules/punycode": {
@@ -3193,7 +4040,7 @@
 			"version": "3.6.0",
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
 			"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-			"dev": true,
+			"devOptional": true,
 			"dependencies": {
 				"inherits": "^2.0.3",
 				"string_decoder": "^1.1.1",
@@ -3268,6 +4115,28 @@
 			"dev": true,
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/retry": {
+			"version": "0.13.1",
+			"resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+			"integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+			"optional": true,
+			"engines": {
+				"node": ">= 4"
+			}
+		},
+		"node_modules/retry-request": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/retry-request/-/retry-request-5.0.1.tgz",
+			"integrity": "sha512-lxFKrlBt0OZzCWh/V0uPEN0vlr3OhdeXnpeY5OES+ckslm791Cb1D5P7lJUSnY7J5hiCjcyaUGmzCnIGDCUBig==",
+			"optional": true,
+			"dependencies": {
+				"debug": "^4.1.1",
+				"extend": "^3.0.2"
+			},
+			"engines": {
+				"node": ">=12"
 			}
 		},
 		"node_modules/reusify": {
@@ -3513,11 +4382,26 @@
 			"integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
 			"dev": true
 		},
+		"node_modules/stream-events": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/stream-events/-/stream-events-1.0.5.tgz",
+			"integrity": "sha512-E1GUzBSgvct8Jsb3v2X15pjzN1tYebtbLaMg+eBOUOAxgbLoSbT2NS91ckc5lJD1KfLjId+jXJRgo0qnV5Nerg==",
+			"optional": true,
+			"dependencies": {
+				"stubs": "^3.0.0"
+			}
+		},
+		"node_modules/stream-shift": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
+			"integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==",
+			"optional": true
+		},
 		"node_modules/string_decoder": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
 			"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-			"dev": true,
+			"devOptional": true,
 			"dependencies": {
 				"safe-buffer": "~5.2.0"
 			}
@@ -3569,6 +4453,12 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
+		},
+		"node_modules/stubs": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/stubs/-/stubs-3.0.0.tgz",
+			"integrity": "sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw==",
+			"optional": true
 		},
 		"node_modules/supports-color": {
 			"version": "7.2.0",
@@ -3741,6 +4631,27 @@
 				"node": ">=10"
 			}
 		},
+		"node_modules/teeny-request": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-8.0.0.tgz",
+			"integrity": "sha512-6KEYxXI4lQPSDkXzXpPmJPNmo7oqduFFbhOEHf8sfsLbXyCsb+umUjBtMGAKhaSToD8JNCtQutTRefu29K64JA==",
+			"optional": true,
+			"dependencies": {
+				"http-proxy-agent": "^5.0.0",
+				"https-proxy-agent": "^5.0.0",
+				"node-fetch": "^2.6.1",
+				"stream-events": "^1.0.5",
+				"uuid": "^8.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/text-decoding": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/text-decoding/-/text-decoding-1.0.0.tgz",
+			"integrity": "sha512-/0TJD42KDnVwKmDK6jj3xP7E2MG7SHAOG4tyTgyUCRPdHwvkquYNLEQltmdMa3owq3TkddCVcTsoctJI8VQNKA=="
+		},
 		"node_modules/text-table": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -3861,6 +4772,14 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
 			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+		},
+		"node_modules/uuid": {
+			"version": "8.3.2",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+			"bin": {
+				"uuid": "dist/bin/uuid"
+			}
 		},
 		"node_modules/v8-compile-cache": {
 			"version": "2.3.0",
@@ -4044,7 +4963,7 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
 			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-			"dev": true
+			"devOptional": true
 		},
 		"node_modules/yargs": {
 			"version": "16.2.0",
@@ -4070,6 +4989,18 @@
 			"engines": {
 				"node": ">=10"
 			}
+		},
+		"node_modules/yocto-queue": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+			"integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+			"optional": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
 		}
 	},
 	"dependencies": {
@@ -4088,6 +5019,14 @@
 				"js-yaml": "^4.1.0",
 				"minimatch": "^3.1.2",
 				"strip-json-comments": "^3.1.1"
+			}
+		},
+		"@fastify/busboy": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-1.1.0.tgz",
+			"integrity": "sha512-Fv854f94v0CzIDllbY3i/0NJPNBRNLDawf3BTYVGCe9VrIIs3Wi7AFx24F9NzCxdf0wyx/x0Q9kEVnvDOPnlxA==",
+			"requires": {
+				"text-decoding": "^1.0.0"
 			}
 		},
 		"@firebase/analytics": {
@@ -4512,6 +5451,68 @@
 			"resolved": "https://registry.npmjs.org/@fontsource/fira-mono/-/fira-mono-4.5.8.tgz",
 			"integrity": "sha512-sFuSPB/Km8B1fy3CH0NqO5Nb4GmVMzp3XFaw6MwK293xhm3OnB68QJawwTTjLewcrS78wOTAhTUB058qxurJoQ=="
 		},
+		"@google-cloud/firestore": {
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/@google-cloud/firestore/-/firestore-5.0.2.tgz",
+			"integrity": "sha512-xlGcNYaW0nvUMzNn2+pLfbEBVt6oysVqtM89faMgZWkWfEtvIQGS0h5PRdLlcqufNzRCX3yIGv29Pb+03ys+VA==",
+			"optional": true,
+			"requires": {
+				"fast-deep-equal": "^3.1.1",
+				"functional-red-black-tree": "^1.0.1",
+				"google-gax": "^2.24.1",
+				"protobufjs": "^6.8.6"
+			}
+		},
+		"@google-cloud/paginator": {
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/@google-cloud/paginator/-/paginator-3.0.7.tgz",
+			"integrity": "sha512-jJNutk0arIQhmpUUQJPJErsojqo834KcyB6X7a1mxuic8i1tKXxde8E69IZxNZawRIlZdIK2QY4WALvlK5MzYQ==",
+			"optional": true,
+			"requires": {
+				"arrify": "^2.0.0",
+				"extend": "^3.0.2"
+			}
+		},
+		"@google-cloud/projectify": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@google-cloud/projectify/-/projectify-3.0.0.tgz",
+			"integrity": "sha512-HRkZsNmjScY6Li8/kb70wjGlDDyLkVk3KvoEo9uIoxSjYLJasGiCch9+PqRVDOCGUFvEIqyogl+BeqILL4OJHA==",
+			"optional": true
+		},
+		"@google-cloud/promisify": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@google-cloud/promisify/-/promisify-3.0.0.tgz",
+			"integrity": "sha512-91ArYvRgXWb73YvEOBMmOcJc0bDRs5yiVHnqkwoG0f3nm7nZuipllz6e7BvFESBvjkDTBC0zMD8QxedUwNLc1A==",
+			"optional": true
+		},
+		"@google-cloud/storage": {
+			"version": "6.2.3",
+			"resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-6.2.3.tgz",
+			"integrity": "sha512-UJqn3Ln8wFBPLuwBaNu3PlhzQDL3EKKfP1+3mzLRQhcFqgpBSMPLDgAXxc6e9S0l0kqsi4GOuAA7fA+l/VAMjQ==",
+			"optional": true,
+			"requires": {
+				"@google-cloud/paginator": "^3.0.7",
+				"@google-cloud/projectify": "^3.0.0",
+				"@google-cloud/promisify": "^3.0.0",
+				"abort-controller": "^3.0.0",
+				"arrify": "^2.0.0",
+				"async-retry": "^1.3.3",
+				"compressible": "^2.0.12",
+				"duplexify": "^4.0.0",
+				"ent": "^2.2.0",
+				"extend": "^3.0.2",
+				"gaxios": "^5.0.0",
+				"google-auth-library": "^8.0.1",
+				"mime": "^3.0.0",
+				"mime-types": "^2.0.8",
+				"p-limit": "^3.0.1",
+				"pumpify": "^2.0.0",
+				"retry-request": "^5.0.0",
+				"stream-events": "^1.0.4",
+				"teeny-request": "^8.0.0",
+				"uuid": "^8.0.0"
+			}
+		},
 		"@grpc/grpc-js": {
 			"version": "1.6.7",
 			"resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.6.7.tgz",
@@ -4620,6 +5621,11 @@
 				"@nodelib/fs.scandir": "2.1.5",
 				"fastq": "^1.6.0"
 			}
+		},
+		"@panva/asn1.js": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@panva/asn1.js/-/asn1.js-1.0.0.tgz",
+			"integrity": "sha512-UdkG3mLEqXgnlKsWanWcgb6dOjUzJ+XC5f+aWw30qrtjxeNUSfKX1cd5FBzOaXQumoe9nIqeZUvrRJS03HCCtw=="
 		},
 		"@playwright/test": {
 			"version": "1.23.2",
@@ -4763,11 +5769,55 @@
 				"svelte-hmr": "^0.14.12"
 			}
 		},
+		"@tootallnate/once": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
+			"integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+			"optional": true
+		},
+		"@types/body-parser": {
+			"version": "1.19.2",
+			"resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz",
+			"integrity": "sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==",
+			"requires": {
+				"@types/connect": "*",
+				"@types/node": "*"
+			}
+		},
+		"@types/connect": {
+			"version": "3.4.35",
+			"resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
+			"integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
+			"requires": {
+				"@types/node": "*"
+			}
+		},
 		"@types/cookie": {
 			"version": "0.5.1",
 			"resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.5.1.tgz",
 			"integrity": "sha512-COUnqfB2+ckwXXSFInsFdOAWQzCCx+a5hq2ruyj+Vjund94RJQd4LG2u9hnvJrTgunKAaax7ancBYlDrNYxA0g==",
 			"dev": true
+		},
+		"@types/express": {
+			"version": "4.17.13",
+			"resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz",
+			"integrity": "sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==",
+			"requires": {
+				"@types/body-parser": "*",
+				"@types/express-serve-static-core": "^4.17.18",
+				"@types/qs": "*",
+				"@types/serve-static": "*"
+			}
+		},
+		"@types/express-serve-static-core": {
+			"version": "4.17.29",
+			"resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.29.tgz",
+			"integrity": "sha512-uMd++6dMKS32EOuw1Uli3e3BPgdLIXmezcfHv7N4c1s3gkhikBplORPpMq3fuWkxncZN1reb16d5n8yhQ80x7Q==",
+			"requires": {
+				"@types/node": "*",
+				"@types/qs": "*",
+				"@types/range-parser": "*"
+			}
 		},
 		"@types/json-schema": {
 			"version": "7.0.11",
@@ -4775,10 +5825,23 @@
 			"integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
 			"dev": true
 		},
+		"@types/jsonwebtoken": {
+			"version": "8.5.8",
+			"resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-8.5.8.tgz",
+			"integrity": "sha512-zm6xBQpFDIDM6o9r6HSgDeIcLy82TKWctCXEPbJJcXb5AKmi5BNNdLXneixK4lplX3PqIVcwLBCGE/kAGnlD4A==",
+			"requires": {
+				"@types/node": "*"
+			}
+		},
 		"@types/long": {
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
 			"integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA=="
+		},
+		"@types/mime": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
+			"integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw=="
 		},
 		"@types/node": {
 			"version": "18.0.3",
@@ -4791,12 +5854,31 @@
 			"integrity": "sha512-SnHmG9wN1UVmagJOnyo/qkk0Z7gejYxOYYmaAwr5u2yFYfsupN3sg10kyzN8Hep/2zbHxCnsumxOoRIRMBwKCg==",
 			"dev": true
 		},
+		"@types/qs": {
+			"version": "6.9.7",
+			"resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
+			"integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw=="
+		},
+		"@types/range-parser": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
+			"integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw=="
+		},
 		"@types/sass": {
 			"version": "1.43.1",
 			"resolved": "https://registry.npmjs.org/@types/sass/-/sass-1.43.1.tgz",
 			"integrity": "sha512-BPdoIt1lfJ6B7rw35ncdwBZrAssjcwzI5LByIrYs+tpXlj/CAkuVdRsgZDdP4lq5EjyWzwxZCqAoFyHKFwp32g==",
 			"dev": true,
 			"requires": {
+				"@types/node": "*"
+			}
+		},
+		"@types/serve-static": {
+			"version": "1.13.10",
+			"resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.10.tgz",
+			"integrity": "sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==",
+			"requires": {
+				"@types/mime": "^1",
 				"@types/node": "*"
 			}
 		},
@@ -4919,6 +6001,15 @@
 			"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
 			"dev": true
 		},
+		"abort-controller": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+			"integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+			"optional": true,
+			"requires": {
+				"event-target-shim": "^5.0.0"
+			}
+		},
 		"acorn": {
 			"version": "8.7.1",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
@@ -4936,7 +6027,7 @@
 			"version": "6.0.2",
 			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
 			"integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-			"dev": true,
+			"devOptional": true,
 			"requires": {
 				"debug": "4"
 			}
@@ -5004,10 +6095,37 @@
 			"integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
 			"dev": true
 		},
+		"arrify": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
+			"integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
+			"optional": true
+		},
+		"async-retry": {
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
+			"integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
+			"optional": true,
+			"requires": {
+				"retry": "0.13.1"
+			}
+		},
 		"balanced-match": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
 			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+		},
+		"base64-js": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+			"optional": true
+		},
+		"bignumber.js": {
+			"version": "9.0.2",
+			"resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.2.tgz",
+			"integrity": "sha512-GAcQvbpsM0pUb0zw1EI0KhQEZ+lRwR5fYaAp3vPOYuP7aDvGy6cVN6XHLauvF8SOga2y0dcLcjt3iQDTSEliyw==",
+			"optional": true
 		},
 		"binary-extensions": {
 			"version": "2.2.0",
@@ -5047,6 +6165,11 @@
 			"resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
 			"integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
 			"dev": true
+		},
+		"buffer-equal-constant-time": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+			"integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
 		},
 		"callsites": {
 			"version": "3.1.0",
@@ -5115,6 +6238,15 @@
 			"integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
 			"dev": true
 		},
+		"compressible": {
+			"version": "2.0.18",
+			"resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
+			"integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
+			"optional": true,
+			"requires": {
+				"mime-db": ">= 1.43.0 < 2"
+			}
+		},
 		"concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -5156,7 +6288,6 @@
 			"version": "4.3.4",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
 			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-			"dev": true,
 			"requires": {
 				"ms": "2.1.2"
 			}
@@ -5209,10 +6340,45 @@
 				"esutils": "^2.0.2"
 			}
 		},
+		"duplexify": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.2.tgz",
+			"integrity": "sha512-fz3OjcNCHmRP12MJoZMPglx8m4rrFP8rovnk4vT8Fs+aonZoCwGg10dSsQsfP/E62eZcPTMSMP6686fu9Qlqtw==",
+			"optional": true,
+			"requires": {
+				"end-of-stream": "^1.4.1",
+				"inherits": "^2.0.3",
+				"readable-stream": "^3.1.1",
+				"stream-shift": "^1.0.0"
+			}
+		},
+		"ecdsa-sig-formatter": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+			"integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+			"requires": {
+				"safe-buffer": "^5.0.1"
+			}
+		},
 		"emoji-regex": {
 			"version": "8.0.0",
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
 			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+		},
+		"end-of-stream": {
+			"version": "1.4.4",
+			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+			"integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+			"optional": true,
+			"requires": {
+				"once": "^1.4.0"
+			}
+		},
+		"ent": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/ent/-/ent-2.2.0.tgz",
+			"integrity": "sha512-GHrMyVZQWvTIdDtpiEXdHZnFQKzeO09apj8Cbl4pKWy4i0Oprcq17usfDt5aO63swf0JOeMWjWQE/LzgSRuWpA==",
+			"optional": true
 		},
 		"es6-promise": {
 			"version": "3.3.1",
@@ -5579,11 +6745,23 @@
 			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
 			"dev": true
 		},
+		"event-target-shim": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+			"integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+			"optional": true
+		},
+		"extend": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+			"optional": true
+		},
 		"fast-deep-equal": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
 			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-			"dev": true
+			"devOptional": true
 		},
 		"fast-glob": {
 			"version": "3.2.11",
@@ -5609,6 +6787,12 @@
 			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
 			"integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
 			"dev": true
+		},
+		"fast-text-encoding": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/fast-text-encoding/-/fast-text-encoding-1.0.4.tgz",
+			"integrity": "sha512-x6lDDm/tBAzX9kmsPcZsNbvDs3Zey3+scsxaZElS8xWLgUMAg/oFLeewfUz0mu1CblHhhsu15jGkraldkFh8KQ==",
+			"optional": true
 		},
 		"fastq": {
 			"version": "1.13.0",
@@ -5685,6 +6869,23 @@
 				"@firebase/util": "1.6.3"
 			}
 		},
+		"firebase-admin": {
+			"version": "11.0.0",
+			"resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-11.0.0.tgz",
+			"integrity": "sha512-x56u+Q1P8QDvQKaYRe29ZUM/3f829cP8tsKCDXOhaIX/GbGfgcdjRhPmCafzlwgCWP5wW9NkOgIhnrw94zucvw==",
+			"requires": {
+				"@fastify/busboy": "^1.1.0",
+				"@firebase/database-compat": "^0.2.0",
+				"@firebase/database-types": "^0.9.7",
+				"@google-cloud/firestore": "^5.0.2",
+				"@google-cloud/storage": "^6.1.0",
+				"@types/node": ">=12.12.47",
+				"jsonwebtoken": "^8.5.1",
+				"jwks-rsa": "^2.0.2",
+				"node-forge": "^1.3.1",
+				"uuid": "^8.3.2"
+			}
+		},
 		"flat-cache": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
@@ -5732,7 +6933,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
 			"integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
-			"dev": true
+			"devOptional": true
 		},
 		"gauge": {
 			"version": "3.0.2",
@@ -5749,6 +6950,28 @@
 				"string-width": "^4.2.3",
 				"strip-ansi": "^6.0.1",
 				"wide-align": "^1.1.2"
+			}
+		},
+		"gaxios": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/gaxios/-/gaxios-5.0.1.tgz",
+			"integrity": "sha512-keK47BGKHyyOVQxgcUaSaFvr3ehZYAlvhvpHXy0YB2itzZef+GqZR8TBsfVRWghdwlKrYsn+8L8i3eblF7Oviw==",
+			"optional": true,
+			"requires": {
+				"extend": "^3.0.2",
+				"https-proxy-agent": "^5.0.0",
+				"is-stream": "^2.0.0",
+				"node-fetch": "^2.6.7"
+			}
+		},
+		"gcp-metadata": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-5.0.0.tgz",
+			"integrity": "sha512-gfwuX3yA3nNsHSWUL4KG90UulNiq922Ukj3wLTrcnX33BB7PwB1o0ubR8KVvXu9nJH+P5w1j2SQSNNqto+H0DA==",
+			"optional": true,
+			"requires": {
+				"gaxios": "^5.0.0",
+				"json-bigint": "^1.0.0"
 			}
 		},
 		"get-caller-file": {
@@ -5813,11 +7036,156 @@
 			"integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
 			"dev": true
 		},
+		"google-auth-library": {
+			"version": "8.1.1",
+			"resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-8.1.1.tgz",
+			"integrity": "sha512-eG3pCfrLgVJe19KhAeZwW0m1LplNEo0FX1GboWf3hu18zD2jq8TUH2K8900AB2YRAuJ7A+1aSXDp1BODjwwRzg==",
+			"optional": true,
+			"requires": {
+				"arrify": "^2.0.0",
+				"base64-js": "^1.3.0",
+				"ecdsa-sig-formatter": "^1.0.11",
+				"fast-text-encoding": "^1.0.0",
+				"gaxios": "^5.0.0",
+				"gcp-metadata": "^5.0.0",
+				"gtoken": "^6.0.0",
+				"jws": "^4.0.0",
+				"lru-cache": "^6.0.0"
+			}
+		},
+		"google-gax": {
+			"version": "2.30.5",
+			"resolved": "https://registry.npmjs.org/google-gax/-/google-gax-2.30.5.tgz",
+			"integrity": "sha512-Jey13YrAN2hfpozHzbtrwEfEHdStJh1GwaQ2+Akh1k0Tv/EuNVSuBtHZoKSBm5wBMvNsxTsEIZ/152NrYyZgxQ==",
+			"optional": true,
+			"requires": {
+				"@grpc/grpc-js": "~1.6.0",
+				"@grpc/proto-loader": "^0.6.12",
+				"@types/long": "^4.0.0",
+				"abort-controller": "^3.0.0",
+				"duplexify": "^4.0.0",
+				"fast-text-encoding": "^1.0.3",
+				"google-auth-library": "^7.14.0",
+				"is-stream-ended": "^0.1.4",
+				"node-fetch": "^2.6.1",
+				"object-hash": "^3.0.0",
+				"proto3-json-serializer": "^0.1.8",
+				"protobufjs": "6.11.3",
+				"retry-request": "^4.0.0"
+			},
+			"dependencies": {
+				"gaxios": {
+					"version": "4.3.3",
+					"resolved": "https://registry.npmjs.org/gaxios/-/gaxios-4.3.3.tgz",
+					"integrity": "sha512-gSaYYIO1Y3wUtdfHmjDUZ8LWaxJQpiavzbF5Kq53akSzvmVg0RfyOcFDbO1KJ/KCGRFz2qG+lS81F0nkr7cRJA==",
+					"optional": true,
+					"requires": {
+						"abort-controller": "^3.0.0",
+						"extend": "^3.0.2",
+						"https-proxy-agent": "^5.0.0",
+						"is-stream": "^2.0.0",
+						"node-fetch": "^2.6.7"
+					}
+				},
+				"gcp-metadata": {
+					"version": "4.3.1",
+					"resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-4.3.1.tgz",
+					"integrity": "sha512-x850LS5N7V1F3UcV7PoupzGsyD6iVwTVvsh3tbXfkctZnBnjW5yu5z1/3k3SehF7TyoTIe78rJs02GMMy+LF+A==",
+					"optional": true,
+					"requires": {
+						"gaxios": "^4.0.0",
+						"json-bigint": "^1.0.0"
+					}
+				},
+				"google-auth-library": {
+					"version": "7.14.1",
+					"resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-7.14.1.tgz",
+					"integrity": "sha512-5Rk7iLNDFhFeBYc3s8l1CqzbEBcdhwR193RlD4vSNFajIcINKI8W8P0JLmBpwymHqqWbX34pJDQu39cSy/6RsA==",
+					"optional": true,
+					"requires": {
+						"arrify": "^2.0.0",
+						"base64-js": "^1.3.0",
+						"ecdsa-sig-formatter": "^1.0.11",
+						"fast-text-encoding": "^1.0.0",
+						"gaxios": "^4.0.0",
+						"gcp-metadata": "^4.2.0",
+						"gtoken": "^5.0.4",
+						"jws": "^4.0.0",
+						"lru-cache": "^6.0.0"
+					}
+				},
+				"google-p12-pem": {
+					"version": "3.1.4",
+					"resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-3.1.4.tgz",
+					"integrity": "sha512-HHuHmkLgwjdmVRngf5+gSmpkyaRI6QmOg77J8tkNBHhNEI62sGHyw4/+UkgyZEI7h84NbWprXDJ+sa3xOYFvTg==",
+					"optional": true,
+					"requires": {
+						"node-forge": "^1.3.1"
+					}
+				},
+				"gtoken": {
+					"version": "5.3.2",
+					"resolved": "https://registry.npmjs.org/gtoken/-/gtoken-5.3.2.tgz",
+					"integrity": "sha512-gkvEKREW7dXWF8NV8pVrKfW7WqReAmjjkMBh6lNCCGOM4ucS0r0YyXXl0r/9Yj8wcW/32ISkfc8h5mPTDbtifQ==",
+					"optional": true,
+					"requires": {
+						"gaxios": "^4.0.0",
+						"google-p12-pem": "^3.1.3",
+						"jws": "^4.0.0"
+					}
+				},
+				"retry-request": {
+					"version": "4.2.2",
+					"resolved": "https://registry.npmjs.org/retry-request/-/retry-request-4.2.2.tgz",
+					"integrity": "sha512-xA93uxUD/rogV7BV59agW/JHPGXeREMWiZc9jhcwY4YdZ7QOtC7qbomYg0n4wyk2lJhggjvKvhNX8wln/Aldhg==",
+					"optional": true,
+					"requires": {
+						"debug": "^4.1.1",
+						"extend": "^3.0.2"
+					}
+				}
+			}
+		},
+		"google-p12-pem": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-4.0.0.tgz",
+			"integrity": "sha512-lRTMn5ElBdDixv4a86bixejPSRk1boRtUowNepeKEVvYiFlkLuAJUVpEz6PfObDHYEKnZWq/9a2zC98xu62A9w==",
+			"optional": true,
+			"requires": {
+				"node-forge": "^1.3.1"
+			}
+		},
 		"graceful-fs": {
 			"version": "4.2.10",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
 			"integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
 			"dev": true
+		},
+		"gtoken": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/gtoken/-/gtoken-6.1.0.tgz",
+			"integrity": "sha512-WPZcFw34wh2LUvbCUWI70GDhOlO7qHpSvFHFqq7d3Wvsf8dIJedE0lnUdOmsKuC0NgflKmF0LxIF38vsGeHHiQ==",
+			"optional": true,
+			"requires": {
+				"gaxios": "^4.0.0",
+				"google-p12-pem": "^4.0.0",
+				"jws": "^4.0.0"
+			},
+			"dependencies": {
+				"gaxios": {
+					"version": "4.3.3",
+					"resolved": "https://registry.npmjs.org/gaxios/-/gaxios-4.3.3.tgz",
+					"integrity": "sha512-gSaYYIO1Y3wUtdfHmjDUZ8LWaxJQpiavzbF5Kq53akSzvmVg0RfyOcFDbO1KJ/KCGRFz2qG+lS81F0nkr7cRJA==",
+					"optional": true,
+					"requires": {
+						"abort-controller": "^3.0.0",
+						"extend": "^3.0.2",
+						"https-proxy-agent": "^5.0.0",
+						"is-stream": "^2.0.0",
+						"node-fetch": "^2.6.7"
+					}
+				}
+			}
 		},
 		"has": {
 			"version": "1.0.3",
@@ -5845,11 +7213,22 @@
 			"resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.8.tgz",
 			"integrity": "sha512-SGeBX54F94Wgu5RH3X5jsDtf4eHyRogWX1XGT3b4HuW3tQPM4AaBzoUji/4AAJNXCEOWZ5O0DgZmJw1947gD5Q=="
 		},
+		"http-proxy-agent": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+			"integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+			"optional": true,
+			"requires": {
+				"@tootallnate/once": "2",
+				"agent-base": "6",
+				"debug": "4"
+			}
+		},
 		"https-proxy-agent": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
 			"integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-			"dev": true,
+			"devOptional": true,
 			"requires": {
 				"agent-base": "6",
 				"debug": "4"
@@ -5953,6 +7332,18 @@
 			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
 			"dev": true
 		},
+		"is-stream": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+			"integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+			"optional": true
+		},
+		"is-stream-ended": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/is-stream-ended/-/is-stream-ended-0.1.4.tgz",
+			"integrity": "sha512-xj0XPvmr7bQFTvirqnFr50o0hQIh6ZItDqloxt5aJrR4NQsYeSsyFQERYGCAzfindAcnKjINnwEEgLx4IqVzQw==",
+			"optional": true
+		},
 		"isarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -5964,6 +7355,14 @@
 			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
 			"dev": true
 		},
+		"jose": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/jose/-/jose-2.0.5.tgz",
+			"integrity": "sha512-BAiDNeDKTMgk4tvD0BbxJ8xHEHBZgpeRZ1zGPPsitSyMgjoMWiLGYAE7H7NpP5h0lPppQajQs871E8NHUrzVPA==",
+			"requires": {
+				"@panva/asn1.js": "^1.0.0"
+			}
+		},
 		"js-yaml": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
@@ -5971,6 +7370,15 @@
 			"dev": true,
 			"requires": {
 				"argparse": "^2.0.1"
+			}
+		},
+		"json-bigint": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+			"integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+			"optional": true,
+			"requires": {
+				"bignumber.js": "^9.0.0"
 			}
 		},
 		"json-schema-traverse": {
@@ -5984,6 +7392,49 @@
 			"resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
 			"integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
 			"dev": true
+		},
+		"jsonwebtoken": {
+			"version": "8.5.1",
+			"resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
+			"integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
+			"requires": {
+				"jws": "^3.2.2",
+				"lodash.includes": "^4.3.0",
+				"lodash.isboolean": "^3.0.3",
+				"lodash.isinteger": "^4.0.4",
+				"lodash.isnumber": "^3.0.3",
+				"lodash.isplainobject": "^4.0.6",
+				"lodash.isstring": "^4.0.1",
+				"lodash.once": "^4.0.0",
+				"ms": "^2.1.1",
+				"semver": "^5.6.0"
+			},
+			"dependencies": {
+				"jwa": {
+					"version": "1.4.1",
+					"resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+					"integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+					"requires": {
+						"buffer-equal-constant-time": "1.0.1",
+						"ecdsa-sig-formatter": "1.0.11",
+						"safe-buffer": "^5.0.1"
+					}
+				},
+				"jws": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+					"integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+					"requires": {
+						"jwa": "^1.4.1",
+						"safe-buffer": "^5.0.1"
+					}
+				},
+				"semver": {
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+				}
+			}
 		},
 		"jszip": {
 			"version": "3.10.0",
@@ -6025,6 +7476,40 @@
 				}
 			}
 		},
+		"jwa": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.0.tgz",
+			"integrity": "sha512-jrZ2Qx916EA+fq9cEAeCROWPTfCwi1IVHqT2tapuqLEVVDKFDENFw1oL+MwrTvH6msKxsd1YTDVw6uKEcsrLEA==",
+			"optional": true,
+			"requires": {
+				"buffer-equal-constant-time": "1.0.1",
+				"ecdsa-sig-formatter": "1.0.11",
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"jwks-rsa": {
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/jwks-rsa/-/jwks-rsa-2.1.4.tgz",
+			"integrity": "sha512-mpArfgPkUpX11lNtGxsF/szkasUcbWHGplZl/uFvFO2NuMHmt0dQXIihh0rkPU2yQd5niQtuUHbXnG/WKiXF6Q==",
+			"requires": {
+				"@types/express": "^4.17.13",
+				"@types/jsonwebtoken": "^8.5.8",
+				"debug": "^4.3.4",
+				"jose": "^2.0.5",
+				"limiter": "^1.1.5",
+				"lru-memoizer": "^2.1.4"
+			}
+		},
+		"jws": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
+			"integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
+			"optional": true,
+			"requires": {
+				"jwa": "^2.0.0",
+				"safe-buffer": "^5.0.1"
+			}
+		},
 		"kleur": {
 			"version": "4.1.5",
 			"resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
@@ -6049,16 +7534,61 @@
 				"immediate": "~3.0.5"
 			}
 		},
+		"limiter": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/limiter/-/limiter-1.1.5.tgz",
+			"integrity": "sha512-FWWMIEOxz3GwUI4Ts/IvgVy6LPvoMPgjMdQ185nN6psJyBJ4yOpzqm695/h5umdLJg2vW3GR5iG11MAkR2AzJA=="
+		},
 		"lodash.camelcase": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
 			"integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA=="
+		},
+		"lodash.clonedeep": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+			"integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ=="
+		},
+		"lodash.includes": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+			"integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w=="
+		},
+		"lodash.isboolean": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+			"integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg=="
+		},
+		"lodash.isinteger": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+			"integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA=="
+		},
+		"lodash.isnumber": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+			"integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw=="
+		},
+		"lodash.isplainobject": {
+			"version": "4.0.6",
+			"resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+			"integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA=="
+		},
+		"lodash.isstring": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+			"integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw=="
 		},
 		"lodash.merge": {
 			"version": "4.6.2",
 			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
 			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
 			"dev": true
+		},
+		"lodash.once": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+			"integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="
 		},
 		"long": {
 			"version": "4.0.0",
@@ -6069,9 +7599,34 @@
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
 			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-			"dev": true,
+			"devOptional": true,
 			"requires": {
 				"yallist": "^4.0.0"
+			}
+		},
+		"lru-memoizer": {
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/lru-memoizer/-/lru-memoizer-2.1.4.tgz",
+			"integrity": "sha512-IXAq50s4qwrOBrXJklY+KhgZF+5y98PDaNo0gi/v2KQBFLyWr+JyFvijZXkGKjQj/h9c0OwoE+JZbwUXce76hQ==",
+			"requires": {
+				"lodash.clonedeep": "^4.5.0",
+				"lru-cache": "~4.0.0"
+			},
+			"dependencies": {
+				"lru-cache": {
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.2.tgz",
+					"integrity": "sha512-uQw9OqphAGiZhkuPlpFGmdTU2tEuhxTourM/19qGJrxBPHAr/f8BT1a0i/lOclESnGatdJG/UCkP9kZB/Lh1iw==",
+					"requires": {
+						"pseudomap": "^1.0.1",
+						"yallist": "^2.0.0"
+					}
+				},
+				"yallist": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+					"integrity": "sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A=="
+				}
 			}
 		},
 		"magic-string": {
@@ -6114,6 +7669,27 @@
 			"requires": {
 				"braces": "^3.0.2",
 				"picomatch": "^2.3.1"
+			}
+		},
+		"mime": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+			"integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
+			"optional": true
+		},
+		"mime-db": {
+			"version": "1.52.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+			"integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+			"optional": true
+		},
+		"mime-types": {
+			"version": "2.1.35",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+			"integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+			"optional": true,
+			"requires": {
+				"mime-db": "1.52.0"
 			}
 		},
 		"min-indent": {
@@ -6179,8 +7755,7 @@
 		"ms": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-			"dev": true
+			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
 		},
 		"nanoid": {
 			"version": "3.3.4",
@@ -6201,6 +7776,11 @@
 			"requires": {
 				"whatwg-url": "^5.0.0"
 			}
+		},
+		"node-forge": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
+			"integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA=="
 		},
 		"node-gyp-build": {
 			"version": "4.5.0",
@@ -6241,6 +7821,12 @@
 			"integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
 			"dev": true
 		},
+		"object-hash": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+			"integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+			"optional": true
+		},
 		"once": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -6261,6 +7847,15 @@
 				"prelude-ls": "^1.2.1",
 				"type-check": "^0.4.0",
 				"word-wrap": "^1.2.3"
+			}
+		},
+		"p-limit": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+			"integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+			"optional": true,
+			"requires": {
+				"yocto-queue": "^0.1.0"
 			}
 		},
 		"pako": {
@@ -6358,6 +7953,15 @@
 			"resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.1.3.tgz",
 			"integrity": "sha512-MG5r82wBzh7pSKDRa9y+vllNHz3e3d4CNj1PQE4BQYxLme0gKYYBm9YENq+UkEikyZ0XbiGWxYlVw3Rl9O/U8g=="
 		},
+		"proto3-json-serializer": {
+			"version": "0.1.9",
+			"resolved": "https://registry.npmjs.org/proto3-json-serializer/-/proto3-json-serializer-0.1.9.tgz",
+			"integrity": "sha512-A60IisqvnuI45qNRygJjrnNjX2TMdQGMY+57tR3nul3ZgO2zXkR9OGR8AXxJhkqx84g0FTnrfi3D5fWMSdANdQ==",
+			"optional": true,
+			"requires": {
+				"protobufjs": "^6.11.2"
+			}
+		},
 		"protobufjs": {
 			"version": "6.11.3",
 			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.3.tgz",
@@ -6378,6 +7982,32 @@
 				"long": "^4.0.0"
 			}
 		},
+		"pseudomap": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+			"integrity": "sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ=="
+		},
+		"pump": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+			"integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+			"optional": true,
+			"requires": {
+				"end-of-stream": "^1.1.0",
+				"once": "^1.3.1"
+			}
+		},
+		"pumpify": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/pumpify/-/pumpify-2.0.1.tgz",
+			"integrity": "sha512-m7KOje7jZxrmutanlkS1daj1dS6z6BgslzOXmcSEpIlCxM3VJH7lG5QLeck/6hgF6F4crFf01UtQmNsJfweTAw==",
+			"optional": true,
+			"requires": {
+				"duplexify": "^4.1.1",
+				"inherits": "^2.0.3",
+				"pump": "^3.0.0"
+			}
+		},
 		"punycode": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
@@ -6394,7 +8024,7 @@
 			"version": "3.6.0",
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
 			"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-			"dev": true,
+			"devOptional": true,
 			"requires": {
 				"inherits": "^2.0.3",
 				"string_decoder": "^1.1.1",
@@ -6443,6 +8073,22 @@
 			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
 			"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
 			"dev": true
+		},
+		"retry": {
+			"version": "0.13.1",
+			"resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+			"integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+			"optional": true
+		},
+		"retry-request": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/retry-request/-/retry-request-5.0.1.tgz",
+			"integrity": "sha512-lxFKrlBt0OZzCWh/V0uPEN0vlr3OhdeXnpeY5OES+ckslm791Cb1D5P7lJUSnY7J5hiCjcyaUGmzCnIGDCUBig==",
+			"optional": true,
+			"requires": {
+				"debug": "^4.1.1",
+				"extend": "^3.0.2"
+			}
 		},
 		"reusify": {
 			"version": "1.0.4",
@@ -6617,11 +8263,26 @@
 			"integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
 			"dev": true
 		},
+		"stream-events": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/stream-events/-/stream-events-1.0.5.tgz",
+			"integrity": "sha512-E1GUzBSgvct8Jsb3v2X15pjzN1tYebtbLaMg+eBOUOAxgbLoSbT2NS91ckc5lJD1KfLjId+jXJRgo0qnV5Nerg==",
+			"optional": true,
+			"requires": {
+				"stubs": "^3.0.0"
+			}
+		},
+		"stream-shift": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
+			"integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==",
+			"optional": true
+		},
 		"string_decoder": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
 			"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-			"dev": true,
+			"devOptional": true,
 			"requires": {
 				"safe-buffer": "~5.2.0"
 			}
@@ -6658,6 +8319,12 @@
 			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
 			"integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
 			"dev": true
+		},
+		"stubs": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/stubs/-/stubs-3.0.0.tgz",
+			"integrity": "sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw==",
+			"optional": true
 		},
 		"supports-color": {
 			"version": "7.2.0",
@@ -6749,6 +8416,24 @@
 					"dev": true
 				}
 			}
+		},
+		"teeny-request": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-8.0.0.tgz",
+			"integrity": "sha512-6KEYxXI4lQPSDkXzXpPmJPNmo7oqduFFbhOEHf8sfsLbXyCsb+umUjBtMGAKhaSToD8JNCtQutTRefu29K64JA==",
+			"optional": true,
+			"requires": {
+				"http-proxy-agent": "^5.0.0",
+				"https-proxy-agent": "^5.0.0",
+				"node-fetch": "^2.6.1",
+				"stream-events": "^1.0.5",
+				"uuid": "^8.0.0"
+			}
+		},
+		"text-decoding": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/text-decoding/-/text-decoding-1.0.0.tgz",
+			"integrity": "sha512-/0TJD42KDnVwKmDK6jj3xP7E2MG7SHAOG4tyTgyUCRPdHwvkquYNLEQltmdMa3owq3TkddCVcTsoctJI8VQNKA=="
 		},
 		"text-table": {
 			"version": "0.2.0",
@@ -6844,6 +8529,11 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
 			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+		},
+		"uuid": {
+			"version": "8.3.2",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
 		},
 		"v8-compile-cache": {
 			"version": "2.3.0",
@@ -6962,7 +8652,7 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
 			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-			"dev": true
+			"devOptional": true
 		},
 		"yargs": {
 			"version": "16.2.0",
@@ -6982,6 +8672,12 @@
 			"version": "20.2.9",
 			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
 			"integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w=="
+		},
+		"yocto-queue": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+			"integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+			"optional": true
 		}
 	}
 }

--- a/client/package.json
+++ b/client/package.json
@@ -36,6 +36,7 @@
 	"dependencies": {
 		"@fontsource/fira-mono": "^4.5.0",
 		"cookie": "^0.4.1",
-		"firebase": "^9.9.0"
+		"firebase": "^9.9.0",
+		"firebase-admin": "^11.0.0"
 	}
 }

--- a/client/src/app.d.ts
+++ b/client/src/app.d.ts
@@ -6,6 +6,10 @@
 declare namespace App {
   interface Locals {
     userid: string;
+    auth?: {
+      uid: string;
+      // Add more claims
+    }
   }
 
   // interface Platform {}

--- a/client/src/hooks.ts
+++ b/client/src/hooks.ts
@@ -1,7 +1,10 @@
+import {auth} from '$lib/firebase/server';
 import type {Handle} from '@sveltejs/kit';
+import {sequence} from '@sveltejs/kit/hooks';
 import * as cookie from 'cookie';
 
-export const handle: Handle = async ({event, resolve}) => {
+/** Built by default by svelte kit to power TODOs app. Can remove eventually. */
+const setUserIdCookie: Handle = async ({event, resolve}) => {
   const cookies = cookie.parse(event.request.headers.get('cookie') || '');
   event.locals.userid = cookies['userid'] || crypto.randomUUID();
 
@@ -21,3 +24,23 @@ export const handle: Handle = async ({event, resolve}) => {
 
   return response;
 };
+
+/** Sends our current firebase authentication JWT to backend on every request */
+const validateFirebaseAuthJWT: Handle = async ({event, resolve}) => {
+  const token = event.request.headers.get('firebase-auth-token');
+  // const cookies = cookie.parse(event.request.headers.get('cookie') || '');
+  // const token = cookies['firebase-auth-token'];
+
+  if (token) {
+    const decodedToken = await auth.verifyIdToken(token);
+    const uid = decodedToken.uid;
+
+    event.locals.auth = {uid};
+  }
+
+  const response = await resolve(event);
+
+  return response;
+};
+
+export const handle = sequence(setUserIdCookie, validateFirebaseAuthJWT);

--- a/client/src/hooks.ts
+++ b/client/src/hooks.ts
@@ -1,5 +1,5 @@
 import {auth} from '$lib/firebase/server';
-import type {Handle} from '@sveltejs/kit';
+import type {GetSession, Handle} from '@sveltejs/kit';
 import {sequence} from '@sveltejs/kit/hooks';
 import * as cookie from 'cookie';
 
@@ -44,3 +44,12 @@ const validateFirebaseAuthJWT: Handle = async ({event, resolve}) => {
 };
 
 export const handle = sequence(setUserIdCookie, validateFirebaseAuthJWT);
+
+/** Sets the Svelte Session based on the locals set by verifying the token. */
+export const getSession: GetSession = (event) => {
+  if (!event.locals.auth) {
+    return {};
+  }
+
+  return {...event.locals.auth};
+};

--- a/client/src/hooks.ts
+++ b/client/src/hooks.ts
@@ -27,12 +27,12 @@ const setUserIdCookie: Handle = async ({event, resolve}) => {
 
 /** Sends our current firebase authentication JWT to backend on every request */
 const validateFirebaseAuthJWT: Handle = async ({event, resolve}) => {
-  const token = event.request.headers.get('firebase-auth-token');
-  // const cookies = cookie.parse(event.request.headers.get('cookie') || '');
-  // const token = cookies['firebase-auth-token'];
+  // const token = event.request.headers.get('firebase-session-token');
+  const cookies = cookie.parse(event.request.headers.get('cookie') || '');
+  const token = cookies['firebase-session-token'];
 
   if (token) {
-    const decodedToken = await auth.verifyIdToken(token);
+    const decodedToken = await auth.verifySessionCookie(token);
     const uid = decodedToken.uid;
 
     event.locals.auth = {uid};

--- a/client/src/lib/Auth.svelte
+++ b/client/src/lib/Auth.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import { initAuth } from './auth';
   
+    // TODO: Update firebase auth module with auth from cookie on startup
     const { loginWithGoogle, logout, user } = initAuth();
   </script>
   

--- a/client/src/lib/auth.ts
+++ b/client/src/lib/auth.ts
@@ -1,6 +1,6 @@
 import {auth} from '$lib/firebase/client';
 import {readable} from 'svelte/store';
-import type {ParsedToken, UserCredential} from 'firebase/auth';
+import type {ParsedToken} from 'firebase/auth';
 import {GoogleAuthProvider, signInWithEmailAndPassword, signInWithPopup, signInWithRedirect} from 'firebase/auth';
 import {browser} from '$app/env';
 
@@ -23,7 +23,7 @@ const userMapper = (claims: ParsedToken): User => ({
 // initialize our firebase app
 export const initAuth = (useRedirect = false) => {
   async function performSessionLogin(token: string) {
-    await fetch('http://localhost:3000/session/login', {
+    await fetch(`${window.location.origin}/session/login`, {
       headers: {accept: 'application/json'},
       method: 'post',
       body: JSON.stringify({idToken: token})
@@ -53,7 +53,7 @@ export const initAuth = (useRedirect = false) => {
 
   const logout = async () => {
     await auth.signOut();
-    await fetch('http://localhost:3000/session/logout', {method: 'post'});
+    await fetch(`${window.location.origin}/session/logout`, {method: 'post'});
   };
 
   // wrap Firebase user in a Svelte readable store

--- a/client/src/lib/auth.ts
+++ b/client/src/lib/auth.ts
@@ -1,15 +1,15 @@
-import { readable } from 'svelte/store';
-import {auth} from '$lib/firebase';
-import type { ParsedToken } from 'firebase/auth';
-import { GoogleAuthProvider, signInWithEmailAndPassword, signInWithPopup, signInWithRedirect } from 'firebase/auth';
+import {auth} from '$lib/firebase/client';
+import {readable} from 'svelte/store';
+import type {ParsedToken} from 'firebase/auth';
+import {GoogleAuthProvider, signInWithEmailAndPassword, signInWithPopup, signInWithRedirect} from 'firebase/auth';
+import {browser} from '$app/env';
 
 // Adapted from https://codechips.me/firebase-authentication-with-svelte/
 
 export type User = {
-    id: string|object|undefined;
-    name: string|object|undefined;
-    email: string|object|undefined;
-    picture: string|object|undefined;
+  id: string|object|undefined; name: string | object | undefined;
+  email: string | object | undefined;
+  picture: string | object | undefined;
 };
 
 const userMapper = (claims: ParsedToken): User => ({
@@ -23,7 +23,7 @@ const userMapper = (claims: ParsedToken): User => ({
 // initialize our firebase app
 export const initAuth = (useRedirect = false) => {
   const loginWithEmailPassword = (email: string, password: string) =>
-    signInWithEmailAndPassword(auth, email, password);
+      signInWithEmailAndPassword(auth, email, password);
 
   const loginWithGoogle = () => {
     const provider = new GoogleAuthProvider();
@@ -41,6 +41,7 @@ export const initAuth = (useRedirect = false) => {
   const user = readable<User|null>(null, set => {
     const unsub = auth.onAuthStateChanged(async fireUser => {
       if (fireUser) {
+        console.log('auth.ts Firebase auth user changed. browser=' + browser);
         const token = await fireUser.getIdTokenResult();
         const user = userMapper(token.claims);
         set(user);
@@ -52,10 +53,5 @@ export const initAuth = (useRedirect = false) => {
     return unsub;
   });
 
-  return {
-    user,
-    loginWithGoogle,
-    loginWithEmailPassword,
-    logout
-  };
+  return {user, loginWithGoogle, loginWithEmailPassword, logout};
 };

--- a/client/src/lib/firebase/client.ts
+++ b/client/src/lib/firebase/client.ts
@@ -1,6 +1,6 @@
 import {browser} from '$app/env';
 import {initializeApp} from 'firebase/app';
-import {getAuth} from 'firebase/auth';
+import {getAuth, inMemoryPersistence} from 'firebase/auth';
 import {getFirestore} from 'firebase/firestore';
 
 const firebaseConfig = {
@@ -16,7 +16,9 @@ const firebaseConfig = {
 // Initialize Firebase
 console.log('Firebase initialized. browser=' + browser);
 const app = initializeApp(firebaseConfig);
+
 const auth = getAuth(app);
+auth.setPersistence(inMemoryPersistence);
 const db = getFirestore(app);
 
 export {app, auth, db};

--- a/client/src/lib/firebase/client.ts
+++ b/client/src/lib/firebase/client.ts
@@ -1,6 +1,7 @@
+import {browser} from '$app/env';
 import {initializeApp} from 'firebase/app';
-import {getFirestore} from 'firebase/firestore';
 import {getAuth} from 'firebase/auth';
+import {getFirestore} from 'firebase/firestore';
 
 const firebaseConfig = {
   apiKey: 'AIzaSyBZV9vyXEFXLbaPQ8pPm-fijhwnkog74x0',
@@ -13,6 +14,7 @@ const firebaseConfig = {
 };
 
 // Initialize Firebase
+console.log('Firebase initialized. browser=' + browser);
 const app = initializeApp(firebaseConfig);
 const auth = getAuth(app);
 const db = getFirestore(app);

--- a/client/src/lib/firebase/server.ts
+++ b/client/src/lib/firebase/server.ts
@@ -1,5 +1,7 @@
 import {initializeApp} from 'firebase-admin';
 
 const admin = initializeApp();
+const db = admin.firestore();
+const auth = admin.auth();
 
-export {admin};
+export {admin, auth, db};

--- a/client/src/lib/firebase/server.ts
+++ b/client/src/lib/firebase/server.ts
@@ -1,0 +1,5 @@
+import {initializeApp} from 'firebase-admin';
+
+const admin = initializeApp();
+
+export {admin};

--- a/client/src/lib/firebase/server.ts
+++ b/client/src/lib/firebase/server.ts
@@ -1,24 +1,23 @@
-import * as fbAdmin from 'firebase-admin';
-const {initializeApp, credential} = fbAdmin;
+import * as admin from 'firebase-admin';
 
 // Initializes Firebase admin
 // https://dev.to/vvo/how-to-add-firebase-service-account-json-files-to-vercel-ph5
 
-let admin: fbAdmin.app.App;
+let app: admin.app.App;
 
 if (process.env.FIREBASE_ADMIN_CREDENTIALS) {
     // Credentials loaded through Environment Variable
     const serviceAccount = JSON.parse(process.env.FIREBASE_ADMIN_CREDENTIALS as string);
 
-    admin = initializeApp({
-        credential: credential.cert(serviceAccount),
+    app = admin.initializeApp({
+        credential: admin.credential.cert(serviceAccount),
     });
 } else {
     // Credentials loaded from file saved in GOOGLE_APPLICATION_CREDENTIALS
-    admin = initializeApp();
+    app = admin.initializeApp();
 }
 
-const db = admin.firestore();
-const auth = admin.auth();
+const db = app.firestore();
+const auth = app.auth();
 
-export {admin, auth, db};
+export {app as admin, auth, db};

--- a/client/src/lib/firebase/server.ts
+++ b/client/src/lib/firebase/server.ts
@@ -1,20 +1,23 @@
-import * as admin from 'firebase-admin';
+/**
+ * @fileoverview
+ * Initializes Firebase admin
+ * https://dev.to/vvo/how-to-add-firebase-service-account-json-files-to-vercel-ph5
+ **/ 
 
-// Initializes Firebase admin
-// https://dev.to/vvo/how-to-add-firebase-service-account-json-files-to-vercel-ph5
+import fbAdmin from 'firebase-admin';
 
-let app: admin.app.App;
+let app: fbAdmin.app.App;
 
 if (process.env.FIREBASE_ADMIN_CREDENTIALS) {
     // Credentials loaded through Environment Variable
     const serviceAccount = JSON.parse(process.env.FIREBASE_ADMIN_CREDENTIALS as string);
 
-    app = admin.initializeApp({
-        credential: admin.credential.cert(serviceAccount),
+    app = fbAdmin.initializeApp({
+        credential: fbAdmin.credential.cert(serviceAccount),
     });
 } else {
     // Credentials loaded from file saved in GOOGLE_APPLICATION_CREDENTIALS
-    app = admin.initializeApp();
+    app = fbAdmin.initializeApp();
 }
 
 const db = app.firestore();

--- a/client/src/lib/firebase/server.ts
+++ b/client/src/lib/firebase/server.ts
@@ -1,6 +1,23 @@
-import {initializeApp} from 'firebase-admin';
+import * as fbAdmin from 'firebase-admin';
+const {initializeApp, credential} = fbAdmin;
 
-const admin = initializeApp();
+// Initializes Firebase admin
+// https://dev.to/vvo/how-to-add-firebase-service-account-json-files-to-vercel-ph5
+
+let admin: fbAdmin.app.App;
+
+if (process.env.FIREBASE_ADMIN_CREDENTIALS) {
+    // Credentials loaded through Environment Variable
+    const serviceAccount = JSON.parse(process.env.FIREBASE_ADMIN_CREDENTIALS as string);
+
+    admin = initializeApp({
+        credential: credential.cert(serviceAccount),
+    });
+} else {
+    // Credentials loaded from file saved in GOOGLE_APPLICATION_CREDENTIALS
+    admin = initializeApp();
+}
+
 const db = admin.firestore();
 const auth = admin.auth();
 

--- a/client/src/routes/media/_types.ts
+++ b/client/src/routes/media/_types.ts
@@ -1,10 +1,11 @@
-import type {DocumentData, FirestoreDataConverter, QueryDocumentSnapshot, Timestamp} from 'firebase/firestore';
+import type {DocumentData, FirestoreDataConverter, QueryDocumentSnapshot} from 'firebase-admin/firestore';
+import { Timestamp } from 'firebase-admin/firestore';
 
 /** Type definition for Media Metadata */
 export type Media = {
   id: string;
   // uid: string;  //
-  created_at: Timestamp;
+  created_at: number;
   pageUrl: string;
   notes: string;  //
   pending_delete: boolean;
@@ -15,18 +16,18 @@ export const mediaConverter: FirestoreDataConverter<Media> = {
     return {
       pageUrl: media.pageUrl,
       notes: media.notes,
-      createdAt: media.created_at,
+      createdAt: Timestamp.fromMillis(media.created_at),
     };
   },
 
-  fromFirestore(snapshot: QueryDocumentSnapshot, options): Media {
-    const data = snapshot.data(options);
+  fromFirestore(snapshot: QueryDocumentSnapshot): Media {
+    const data = snapshot.data();
     return {
       id: snapshot.id,
       // uid: snapshot.id,
       pageUrl: data.pageUrl,
       notes: data.notes,
-      created_at: data.createdAt,
+      created_at: (data.createdAt as Timestamp).toMillis(),
       pending_delete: false,
     };
   }

--- a/client/src/routes/media/_types.ts
+++ b/client/src/routes/media/_types.ts
@@ -2,7 +2,8 @@ import type {DocumentData, FirestoreDataConverter, QueryDocumentSnapshot, Timest
 
 /** Type definition for Media Metadata */
 export type Media = {
-  uid: string;  //
+  id: string;
+  // uid: string;  //
   created_at: Timestamp;
   pageUrl: string;
   notes: string;  //
@@ -21,7 +22,8 @@ export const mediaConverter: FirestoreDataConverter<Media> = {
   fromFirestore(snapshot: QueryDocumentSnapshot, options): Media {
     const data = snapshot.data(options);
     return {
-      uid: snapshot.id,
+      id: snapshot.id,
+      // uid: snapshot.id,
       pageUrl: data.pageUrl,
       notes: data.notes,
       created_at: data.createdAt,

--- a/client/src/routes/media/import/count.ts
+++ b/client/src/routes/media/import/count.ts
@@ -1,0 +1,36 @@
+/*
+ * @fileoverview Testing endpoint for a simple count collection elements query
+ * verifying the auth sent over.
+ */
+
+import type {RequestHandler} from '@sveltejs/kit';
+import {db, auth} from '$lib/firebase/server';
+
+export const get: RequestHandler = async ({request}) => {
+  console.log('/media/list/count called');
+  const token = request.headers.get('firebase-auth-token');
+
+  if (!token) return {status: 403};
+
+  try {
+    const decodedToken = await auth.verifyIdToken(token);
+    const uid = decodedToken.uid;
+
+    console.log('Count got an auth UID of ' + uid);
+    if (uid !== 'CGrN3Ndk3vhhIjQUSPqv7yd9OJF3') {
+      return {
+        status: 403,
+        body: {
+          error: `User ${uid} is not authorized for this endpoint.`,
+        },
+      };
+    }
+
+    const count =
+        await db.collection('media-metadata').get().then(snap => snap.size);
+
+    return {status: 200, body: JSON.stringify({count})};
+  } catch (reason) {
+    return {status: 400, body: JSON.stringify({error: reason})};
+  }
+};

--- a/client/src/routes/media/import/count.ts
+++ b/client/src/routes/media/import/count.ts
@@ -23,7 +23,7 @@ export const get: RequestHandler = async ({locals}) => {
   }
 
   const count =
-      await db.collection('media-metadata').get().then(snap => snap.size);
+      await db.collection('media-metadata').limit(1).get().then(snap => snap.size);
 
   return {status: 200, body: JSON.stringify({count})};
 };

--- a/client/src/routes/media/import/count.ts
+++ b/client/src/routes/media/import/count.ts
@@ -4,33 +4,26 @@
  */
 
 import type {RequestHandler} from '@sveltejs/kit';
-import {db, auth} from '$lib/firebase/server';
+import {db} from '$lib/firebase/server';
 
-export const get: RequestHandler = async ({request}) => {
+export const get: RequestHandler = async ({locals}) => {
   console.log('/media/list/count called');
-  const token = request.headers.get('firebase-auth-token');
+  const uid = locals.auth?.uid;
+  console.log('Request has uid: ' + uid);
 
-  if (!token) return {status: 403};
+  if (!uid) return {status: 403};
 
-  try {
-    const decodedToken = await auth.verifyIdToken(token);
-    const uid = decodedToken.uid;
-
-    console.log('Count got an auth UID of ' + uid);
-    if (uid !== 'CGrN3Ndk3vhhIjQUSPqv7yd9OJF3') {
-      return {
-        status: 403,
-        body: {
-          error: `User ${uid} is not authorized for this endpoint.`,
-        },
-      };
-    }
-
-    const count =
-        await db.collection('media-metadata').get().then(snap => snap.size);
-
-    return {status: 200, body: JSON.stringify({count})};
-  } catch (reason) {
-    return {status: 400, body: JSON.stringify({error: reason})};
+  if (uid !== 'CGrN3Ndk3vhhIjQUSPqv7yd9OJF3') {
+    return {
+      status: 403,
+      body: {
+        error: `User ${uid} is not authorized for this endpoint.`,
+      },
+    };
   }
+
+  const count =
+      await db.collection('media-metadata').get().then(snap => snap.size);
+
+  return {status: 200, body: JSON.stringify({count})};
 };

--- a/client/src/routes/media/import/index.svelte
+++ b/client/src/routes/media/import/index.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import { auth } from '$lib/firebase/client';
 	import { enhance } from '$lib/form';
-	import type { Load } from '.svelte-kit/types/src/routes/media/import/__types';
 	import { onMount } from 'svelte';
 
 	let count = 0;

--- a/client/src/routes/media/import/index.svelte
+++ b/client/src/routes/media/import/index.svelte
@@ -1,18 +1,11 @@
 <script lang="ts">
-	import { auth } from '$lib/firebase/client';
 	import { enhance } from '$lib/form';
 	import { onMount } from 'svelte';
 
 	let count = 0;
 
 	onMount(async () => {
-		const authToken = await auth.currentUser?.getIdToken();
-
 		const headers: HeadersInit = { 'Content-Type': 'application/json' };
-
-		if (authToken) {
-			headers['firebase-auth-token'] = authToken;
-		}
 
 		try {
 			const response = await fetch('/media/import/count', {

--- a/client/src/routes/media/import/index.svelte
+++ b/client/src/routes/media/import/index.svelte
@@ -1,5 +1,34 @@
 <script lang="ts">
+	import { auth } from '$lib/firebase/client';
 	import { enhance } from '$lib/form';
+	import type { Load } from '.svelte-kit/types/src/routes/media/import/__types';
+	import { onMount } from 'svelte';
+
+	let count = 0;
+
+	onMount(async () => {
+		const authToken = await auth.currentUser?.getIdToken();
+
+		const headers: HeadersInit = { 'Content-Type': 'application/json' };
+
+		if (authToken) {
+			headers['firebase-auth-token'] = authToken;
+		}
+
+		try {
+			const response = await fetch('/media/import/count', {
+				method: 'GET',
+				headers,
+			});
+			console.log(response);
+			const body = await response.json();
+			console.log(body);
+
+			count = body.count;
+		} catch (error) {
+			console.error(`Error in load function for /: ${error}`);
+		}
+	});
 </script>
 
 <svelte:head>
@@ -9,6 +38,8 @@
 
 <div class="bulk-import">
 	<h1>Media Bulk Import</h1>
+
+	<h3>Count: {count}</h3>
 
 	<form
 		class="import"

--- a/client/src/routes/media/import/index.ts
+++ b/client/src/routes/media/import/index.ts
@@ -1,6 +1,6 @@
 import type {Media} from '../_types';
 import type {RequestHandler} from './__types';
-import {db} from '$lib/firebase';
+import {db} from '$lib/firebase/client';
 import type {WriteBatch} from 'firebase/firestore';
 import {collection, doc, Timestamp, writeBatch} from 'firebase/firestore';
 

--- a/client/src/routes/media/list/index.svelte
+++ b/client/src/routes/media/list/index.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+	import { auth } from '$lib/firebase/client';
+
 	import { enhance } from '$lib/form';
 	import type { Media } from '../_types';
 

--- a/client/src/routes/media/list/index.svelte
+++ b/client/src/routes/media/list/index.svelte
@@ -1,6 +1,4 @@
 <script lang="ts">
-	import { auth } from '$lib/firebase/client';
-
 	import { enhance } from '$lib/form';
 	import type { Media } from '../_types';
 

--- a/client/src/routes/media/list/index.svelte
+++ b/client/src/routes/media/list/index.svelte
@@ -28,7 +28,7 @@
 		<input name="text" aria-label="Add Media Page URL" placeholder="+ tap to record a page URL" />
 	</form>
 
-	{#each mediaList as media (media.uid)}
+	{#each mediaList as media (media.id)}
 		<div class="media">
 			<span class="text">{media.pageUrl}</span>
 
@@ -39,7 +39,7 @@
 					pending: () => (media.pending_delete = true),
 				}}
 			>
-				<input type="hidden" name="uid" value={media.uid} />
+				<input type="hidden" name="uid" value={media.id} />
 				<button class="delete" aria-label="Delete todo" disabled={media.pending_delete} />
 			</form>
 		</div>

--- a/client/src/routes/media/list/index.ts
+++ b/client/src/routes/media/list/index.ts
@@ -4,7 +4,10 @@ import {mediaConverter, type Media} from '../_types';
 import {browser} from '$app/env';
 
 export const get: RequestHandler = async ({locals}) => {
-  // TODO: Implement permissions using locals.
+  const uid = locals.auth?.uid;
+  console.log('Request has uid: ' + uid);
+
+  if (!uid) return {status: 403};
 
   console.log('media/list GET running browser=' + browser);
   const metadataCol = db.collection('media-metadata').limit(50).withConverter(mediaConverter);

--- a/client/src/routes/media/list/index.ts
+++ b/client/src/routes/media/list/index.ts
@@ -1,9 +1,11 @@
 import type {RequestHandler} from './__types';
-import {db} from '$lib/firebase';
+import {db, auth} from '$lib/firebase/client';
 import {collection, deleteDoc, doc, getDocs, limit, query} from 'firebase/firestore';
 import {mediaConverter, type Media} from '../_types';
+import {browser} from '$app/env';
 
 export const get: RequestHandler = async () => {
+  console.log('media/list GET running browser=' + browser);
   const metadataCol =
       collection(db, 'media-metadata').withConverter(mediaConverter);
   const q = query(metadataCol, limit(50));

--- a/client/src/routes/media/list/index.ts
+++ b/client/src/routes/media/list/index.ts
@@ -2,6 +2,7 @@ import type {RequestHandler} from './__types';
 import {db} from '$lib/firebase/server';
 import type {Media} from '../_types';
 import {browser} from '$app/env';
+import { doc, type FirestoreDataConverter } from 'firebase/firestore';
 
 export const get: RequestHandler = async ({locals}) => {
   // TODO: Implement permissions using locals.
@@ -12,7 +13,7 @@ export const get: RequestHandler = async ({locals}) => {
 
   const snapshot = await q;
   const mediaList: Media[] = [];
-  snapshot.forEach((doc) => mediaList.push(doc.data() as Media));
+  snapshot.forEach((doc) => mediaList.push({id: doc.id, ...doc.data()} as Media));
 
   return {status: 200, body: {mediaList}};
 };

--- a/client/src/routes/media/list/index.ts
+++ b/client/src/routes/media/list/index.ts
@@ -1,19 +1,18 @@
 import type {RequestHandler} from './__types';
 import {db} from '$lib/firebase/server';
-import type {Media} from '../_types';
+import {mediaConverter, type Media} from '../_types';
 import {browser} from '$app/env';
-import { doc, type FirestoreDataConverter } from 'firebase/firestore';
 
 export const get: RequestHandler = async ({locals}) => {
   // TODO: Implement permissions using locals.
 
   console.log('media/list GET running browser=' + browser);
-  const metadataCol = db.collection('media-metadata').limit(50);
+  const metadataCol = db.collection('media-metadata').limit(50).withConverter(mediaConverter);
   const q = metadataCol.get();
 
   const snapshot = await q;
   const mediaList: Media[] = [];
-  snapshot.forEach((doc) => mediaList.push({id: doc.id, ...doc.data()} as Media));
+  snapshot.forEach((doc) => mediaList.push(doc.data()));
 
   return {status: 200, body: {mediaList}};
 };

--- a/client/src/routes/media/list/index.ts
+++ b/client/src/routes/media/list/index.ts
@@ -1,18 +1,18 @@
 import type {RequestHandler} from './__types';
-import {db} from '$lib/firebase/client';
-import {collection, deleteDoc, doc, getDocs, limit, query} from 'firebase/firestore';
-import {mediaConverter, type Media} from '../_types';
+import {db} from '$lib/firebase/server';
+import type {Media} from '../_types';
 import {browser} from '$app/env';
 
-export const get: RequestHandler = async () => {
-  console.log('media/list GET running browser=' + browser);
-  const metadataCol =
-      collection(db, 'media-metadata').withConverter(mediaConverter);
-  const q = query(metadataCol, limit(50));
+export const get: RequestHandler = async ({locals}) => {
+  // TODO: Implement permissions using locals.
 
-  const snapshot = await getDocs(q);
+  console.log('media/list GET running browser=' + browser);
+  const metadataCol = db.collection('media-metadata').limit(50);
+  const q = metadataCol.get();
+
+  const snapshot = await q;
   const mediaList: Media[] = [];
-  snapshot.forEach((doc) => mediaList.push(doc.data()));
+  snapshot.forEach((doc) => mediaList.push(doc.data() as Media));
 
   return {status: 200, body: {mediaList}};
 };
@@ -22,9 +22,9 @@ export const del: RequestHandler = async ({request}) => {
 
   const uid = form.get('uid');
 
-  const ref = doc(db, 'media-metadata/' + uid);
+  const ref = db.doc('media-metadata/' + uid);
 
-  return deleteDoc(ref)
+  return ref.delete()
       .then(() => {
         return {status: 200};
       })

--- a/client/src/routes/media/list/index.ts
+++ b/client/src/routes/media/list/index.ts
@@ -1,5 +1,5 @@
 import type {RequestHandler} from './__types';
-import {db, auth} from '$lib/firebase/client';
+import {db} from '$lib/firebase/client';
 import {collection, deleteDoc, doc, getDocs, limit, query} from 'firebase/firestore';
 import {mediaConverter, type Media} from '../_types';
 import {browser} from '$app/env';

--- a/client/src/routes/session/login.ts
+++ b/client/src/routes/session/login.ts
@@ -1,0 +1,39 @@
+import {auth} from '$lib/firebase/server';
+import type {RequestHandler} from '@sveltejs/kit';
+import * as cookie from 'cookie';
+
+export const post: RequestHandler = async ({request}) => {
+  // Get the ID token passed and the CSRF token.
+  const {idToken} = await request.json();
+  // const csrfToken = request.body.csrfToken.toString();
+  // Guard against CSRF attacks.
+  // if (csrfToken !== request.cookies.csrfToken) {
+  //   res.status(401).send('UNAUTHORIZED REQUEST!');
+  //   return;
+  // }
+
+  // Set session expiration to 5 days.
+  const expiresIn = 60 * 60 * 24 * 5 * 1000;
+  // Create the session cookie. This will also verify the ID token in the
+  // process. The session cookie will have the same claims as the ID token. To
+  // only allow session cookie setting on recent sign-in, auth_time in ID token
+  // can be checked to ensure user was recently signed in before creating a
+  // session cookie.
+  const sessionCookie = await auth.createSessionCookie(idToken, {expiresIn})
+
+  // Set cookie policy for session cookie.
+  const options = {maxAge: expiresIn, httpOnly: true, secure: true};
+  return {
+    headers: {
+      'set-cookie': [
+        cookie.serialize('firebase-auth-token', sessionCookie, options),
+      ]
+    },
+    status: 200,
+  };
+
+  // TODO catch the error if createSessionCookie fails
+  // catch (error) {
+  //   return {status: 401, body: 'UNAUTHORIZED REQUEST!'};
+  // };
+};

--- a/client/src/routes/session/login.ts
+++ b/client/src/routes/session/login.ts
@@ -22,11 +22,17 @@ export const post: RequestHandler = async ({request}) => {
   const sessionCookie = await auth.createSessionCookie(idToken, {expiresIn})
 
   // Set cookie policy for session cookie.
-  const options = {maxAge: expiresIn, httpOnly: true, secure: true};
+  const options: cookie.CookieSerializeOptions = {
+    path: '/',
+    maxAge: expiresIn,
+    httpOnly: true,
+    secure: true
+  };
+
   return {
     headers: {
       'set-cookie': [
-        cookie.serialize('firebase-auth-token', sessionCookie, options),
+        cookie.serialize('firebase-session-token', sessionCookie, options),
       ]
     },
     status: 200,

--- a/client/src/routes/session/logout.ts
+++ b/client/src/routes/session/logout.ts
@@ -1,0 +1,23 @@
+import {auth} from '$lib/firebase/server';
+import type {RequestHandler} from '@sveltejs/kit';
+import * as cookie from 'cookie';
+
+export const post: RequestHandler = async ({request}) => {
+  const cookies = cookie.parse(request.headers.get('cookie') || '');
+  const sessionCookie = cookies['firebase-auth-token'];
+
+  if (sessionCookie) {
+    // Revoke refresh tokens to force a full re-login
+    await auth.verifySessionCookie(sessionCookie)
+        .then(decodedToken => auth.revokeRefreshTokens(decodedToken.sub));
+  }
+
+  return {
+    status: 303, headers: {
+      location: '/',
+      // Explicitly set a maxAge of zero to void the cookie immediately
+      // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie
+      'set-cookie': cookie.serialize('firebase-auth-token', '', {maxAge: 0}),
+    }
+  }
+};

--- a/client/src/routes/session/logout.ts
+++ b/client/src/routes/session/logout.ts
@@ -4,7 +4,7 @@ import * as cookie from 'cookie';
 
 export const post: RequestHandler = async ({request}) => {
   const cookies = cookie.parse(request.headers.get('cookie') || '');
-  const sessionCookie = cookies['firebase-auth-token'];
+  const sessionCookie = cookies['firebase-session-token'];
 
   if (sessionCookie) {
     // Revoke refresh tokens to force a full re-login
@@ -12,12 +12,20 @@ export const post: RequestHandler = async ({request}) => {
         .then(decodedToken => auth.revokeRefreshTokens(decodedToken.sub));
   }
 
+  // Set cookie policy for session cookie.
+  const options: cookie.CookieSerializeOptions = {
+    path: '/',
+    maxAge: 0,
+    httpOnly: true,
+    secure: true,
+  };
+
   return {
-    status: 303, headers: {
-      location: '/',
+    status: 200,
+    headers: {
       // Explicitly set a maxAge of zero to void the cookie immediately
       // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie
-      'set-cookie': cookie.serialize('firebase-auth-token', '', {maxAge: 0}),
-    }
+      'set-cookie': cookie.serialize('firebase-session-token', '', options),
+    },
   }
 };

--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -1,8 +1,15 @@
 import { sveltekit } from '@sveltejs/kit/vite';
+import { defineConfig } from 'vite';
 
-/** @type {import('vite').UserConfig} */
-const config = {
-	plugins: [sveltekit()]
-};
+/** @type {import('vite').UserConfigExport} */
+export default defineConfig(() => {
+	// const env = loadEnv(mode, process.cwd(), '');
+	// See https://firebase.google.com/docs/admin/setup#initialize-sdk for getting these creds
+	process.env[
+		'GOOGLE_APPLICATION_CREDENTIALS'
+	] = `${process.cwd()}/shisho-app-firebase-adminsdk-1ltb7-fbe973716c.json`;
 
-export default config;
+	return {
+		plugins: [sveltekit()],
+	};
+});

--- a/wiki/Firebase.md
+++ b/wiki/Firebase.md
@@ -8,3 +8,9 @@ I've limited database rules to only logged in users, but this isn't super secure
 I'd like to follow the above article to setup a custom claim for "admin" or "authorized" users
 
 TODO: Fix up firebase firestore rules
+
+# Admin Authentication
+
+It seems like a backend server cannot directly use a client authentication for use against firestore rules. You need to verify and decode the token and implement the permissioning yourself.
+
+https://stackoverflow.com/a/62946422

--- a/wiki/Vercel.md
+++ b/wiki/Vercel.md
@@ -1,0 +1,8 @@
+# Vercel Integration
+
+Vercel can be auto-configured to recieve events from your repo and build/deploy from the main branch.
+
+https://dev.to/vvo/how-to-add-firebase-service-account-json-files-to-vercel-ph5
+
+This article talks about how to hook in the Firebase Admin service account email as a JSON encoded environment variable on Vercel.
+


### PR DESCRIPTION
Adds user authentication using the Firebase/Auth module

Instead of the default auth persistence, we use session tokens stored on firebase and kept in a cookie on the clients browser.
Splits the firebase initialization into client/server files for use in different functions.
Updates the firebase related endpoints to use FirebaseAdmin.Firestore, and to be auth protected.

Requires setting an environment variable to enable the Backend. I've set this secret on Vercel for the deployment.